### PR TITLE
feat: usage-truth layer with enriched spend/usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Layer 2 is 100% optional. If it fails, the report renders perfectly without it.
 | `--no-cache` | Bypass cache |
 | `--cache-ttl-ms N` | Override cache TTL (default: 45000) |
 | `--lookback-hours N` | Enrichment lookback period (default: 24) |
+| `--anthropic-source auto|api|subscription` | Anthropic source mode: auto (subscription via Claude `/usage`, API via fallback), api (force OpenClaw usage fallback), or subscription (force Claude `/usage`) |
 
 ---
 
@@ -44,10 +45,22 @@ Layer 2 is 100% optional. If it fails, the report renders perfectly without it.
 | Adapter | Provider | Source | Priority |
 |---------|----------|--------|----------|
 | `openai-codex-oauth` | OpenAI/Codex | `~/.codex/auth.json` → OAuth usage API | Direct (primary) |
+| `anthropic-cli-usage` | Anthropic (subscription) | Claude CLI `/usage` via tmux session | Direct (primary for subscription mode) |
 | `venice-diem` | Venice | Diem plugin script → HTTP headers | Direct (primary) |
-| `openclaw-status` | All | `openclaw status --usage --json` | Fallback |
+| `openclaw-status` | All | `openclaw status --usage --json` | Fallback (and Anthropic API mode source) |
 
 Direct adapters take priority. If they fail or aren't available, `openclaw-status` fills the gap.
+
+### Anthropic source behavior
+
+- **auto** (default): uses direct Claude `/usage` data when subscription windows are present; falls back to `openclaw status --usage` for API-style usage.
+- **api**: disables Claude `/usage` adapter and forces Anthropic data from `openclaw status` fallback.
+- **subscription**: requires Claude `/usage` subscription windows (same source as Anthrometer).
+
+Optional env overrides for the Anthropic adapter:
+- `TIDE_POOLS_ANTHROPIC_TMUX_SESSION` (default: `claude_usage_cmd`)
+- `TIDE_POOLS_ANTHROPIC_CLAUDE_CMD` (default: `claude`)
+- `TIDE_POOLS_ANTHROPIC_TIMEOUT_MS` (default: `20000`)
 
 ### Adding the Codex OAuth adapter
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tide Pool v2 🌊🦞
+# Tide Pools v2 🌊🦞
 
 Provider usage at a glance — with **dashboard-accurate numbers** and session breakdowns.
 
@@ -60,13 +60,13 @@ npm install -g @openai/codex
 codex auth
 ```
 
-This creates `~/.codex/auth.json`. Tide Pool reads the OAuth token and hits OpenAI's usage endpoint directly — the same source the web dashboard uses. If the file doesn't exist, the adapter is silently skipped.
+This creates `~/.codex/auth.json`. Tide Pools reads the OAuth token and hits OpenAI's usage endpoint directly — the same source the web dashboard uses. If the file doesn't exist, the adapter is silently skipped.
 
 ---
 
 ## Enrichment
 
-When enabled (default), Tide Pool scans recent session JSONL logs to show:
+When enabled (default), Tide Pools scans recent session JSONL logs to show:
 
 - Per-session token usage (which sessions burned what)
 - Cost breakdown (when pricing data available)
@@ -84,7 +84,7 @@ Put the plugin in your OpenClaw extensions:
 
 ```
 ~/.openclaw/extensions/
-└── tide-pool/
+└── tide-pools/
     ├── openclaw.plugin.json
     ├── index.ts
     ├── usage-core.mjs
@@ -100,8 +100,8 @@ Put the plugin in your OpenClaw extensions:
 
 Ensure your `openclaw.json` includes:
 
-- `plugins.allow` contains `"tide-pool"`
-- `plugins.entries["tide-pool"].enabled = true`
+- `plugins.allow` contains `"tide-pools"`
+- `plugins.entries["tide-pools"].enabled = true`
 
 Restart gateway. ✅
 
@@ -110,7 +110,7 @@ Restart gateway. ✅
 ## Example Output
 
 ```
-🌊 Tide Pool
+🌊 Tide Pools
 
 • OpenAI Codex [plus]: 5h: 93% left (in 2h 15m) | Day: 48% left (in 4d 17h) — via OpenClaw status
 • Venice [Diem]: Diem: 1,247.3200 | Requests: 980/1000 (98% left) — via Diem API

--- a/README.md
+++ b/README.md
@@ -1,95 +1,127 @@
-# Tide Pool Plugin 🌊🦞✨
+# Tide Pool v2 🌊🦞
 
-A cheerful little OpenClaw plugin that gives you **provider usage at a glance** with **zero LLM inference** for command handling.
-
-Think of it as your quota shoreline: one look, and you know what’s still swimming. 🐟
+Provider usage at a glance — with **dashboard-accurate numbers** and session breakdowns.
 
 ---
 
-## 🧭 What this plugin does
+## What changed in v2
 
-• Adds direct slash commands for quota visibility  
-• Works without invoking the main AI for command parsing  
-• Supports plain + themed output  
-• Optionally augments Venice via your existing Diem plugin
+v1 had one source per provider: `openclaw status --usage`. v2 introduces **source adapters** that hit provider APIs directly for more accurate data, plus an **enrichment layer** that mines session logs to show where your usage went.
 
----
+### Architecture
 
-## 🗣️ Commands
+```
+Layer 1 (Accuracy)     → Adapter registry: direct provider APIs with fallback
+Layer 2 (Enrichment)   → Session JSONL mining: per-session token breakdown
+```
 
-• `/tide_pool`  
-  Tide-themed human-readable status board 🌊
-
-• `/tidepool`  
-  Alias for `/tide_pool`
-
-• `/lobster_usage`  
-  Legacy alias for `/tide_pool` (kept for compatibility)
-
-• `/quota_all`  
-  Plain status board
-
-• `/quota_all --json`  
-  Machine-readable JSON snapshot
-
-### Optional flags on `/quota_all`
-
-• `--json` → JSON output  
-• `--no-venice` → skip Venice augmentation from diem plugin  
-• `--no-cache` → bypass short cache  
-• `--cache-ttl-ms <N>` → override cache TTL (default: `45000`)
+Layer 2 is 100% optional. If it fails, the report renders perfectly without it.
 
 ---
 
-## 📦 Where to put this folder (noob-friendly)
+## Commands
 
-Put the plugin here on your OpenClaw host:
+| Command | Description |
+|---------|-------------|
+| `/tide_pool` | Tide-themed report (providers + session breakdown) |
+| `/tidepool` | Alias |
+| `/lobster_usage` | Legacy alias |
+| `/quota_all` | Plain report (supports flags below) |
 
-```text
+### Flags on `/quota_all`
+
+| Flag | Effect |
+|------|--------|
+| `--json` | JSON output |
+| `--no-venice` | Skip Venice/Diem probe |
+| `--no-enrich` | Skip session JSONL enrichment |
+| `--no-cache` | Bypass cache |
+| `--cache-ttl-ms N` | Override cache TTL (default: 45000) |
+| `--lookback-hours N` | Enrichment lookback period (default: 24) |
+
+---
+
+## Source Adapters
+
+| Adapter | Provider | Source | Priority |
+|---------|----------|--------|----------|
+| `openai-codex-oauth` | OpenAI/Codex | `~/.codex/auth.json` → OAuth usage API | Direct (primary) |
+| `venice-diem` | Venice | Diem plugin script → HTTP headers | Direct (primary) |
+| `openclaw-status` | All | `openclaw status --usage --json` | Fallback |
+
+Direct adapters take priority. If they fail or aren't available, `openclaw-status` fills the gap.
+
+### Adding the Codex OAuth adapter
+
+Install the Codex CLI and authenticate:
+
+```bash
+npm install -g @openai/codex
+codex auth
+```
+
+This creates `~/.codex/auth.json`. Tide Pool reads the OAuth token and hits OpenAI's usage endpoint directly — the same source the web dashboard uses. If the file doesn't exist, the adapter is silently skipped.
+
+---
+
+## Enrichment
+
+When enabled (default), Tide Pool scans recent session JSONL logs to show:
+
+- Per-session token usage (which sessions burned what)
+- Cost breakdown (when pricing data available)
+- Total tokens and cost for the lookback period
+
+This data comes from OpenClaw's own session logs — it answers "where did my usage go?" while the adapters answer "how much do I have left?"
+
+**Fault-isolated:** If enrichment fails for any reason (missing files, parse errors, permission issues), the main provider report still renders cleanly. The session breakdown section simply doesn't appear.
+
+---
+
+## Installation
+
+Put the plugin in your OpenClaw extensions:
+
+```
 ~/.openclaw/extensions/
 └── tide-pool/
     ├── openclaw.plugin.json
     ├── index.ts
     ├── usage-core.mjs
+    ├── enrichment.mjs
     ├── cli.mjs
+    ├── adapters/
+    │   ├── index.mjs
+    │   ├── openclaw-status.mjs
+    │   ├── openai-codex-oauth.mjs
+    │   └── venice-diem.mjs
     └── README.md
 ```
 
-Then ensure your `openclaw.json` includes:
+Ensure your `openclaw.json` includes:
 
-• `plugins.allow` contains `"tide-pool"`  
-• `plugins.entries["tide-pool"].enabled = true`
+- `plugins.allow` contains `"tide-pool"`
+- `plugins.entries["tide-pool"].enabled = true`
 
-Then restart gateway. ✅
-
----
-
-## 🪙 Venice support
-
-If `openclaw status --usage` doesn’t show Venice directly, Tide Pool can enrich output via:
-
-`~/.openclaw/extensions/diem/diem.py`
-
-If that script is missing/unavailable, Tide Pool still works and reports Venice as unavailable.
+Restart gateway. ✅
 
 ---
 
-## 🤝 Bottom Feeder integration
+## Example Output
 
-Bottom Feeder can consume Tide Pool directly via:
+```
+🌊 Tide Pool
 
-`skills/bottom-feeder/scripts/provider-usage.sh`
+• OpenAI Codex [plus]: 5h: 93% left (in 2h 15m) | Day: 48% left (in 4d 17h) — via OpenClaw status
+• Venice [Diem]: Diem: 1,247.3200 | Requests: 980/1000 (98% left) — via Diem API
 
-It checks Tide Pool first, then legacy lobster path, then falls back to `openclaw status --usage --json`.
-
----
-
-## 🧩 Files in this plugin
-
-• `openclaw.plugin.json` — plugin manifest  
-• `index.ts` — command registration  
-• `usage-core.mjs` — usage collection + formatting logic  
-• `cli.mjs` — CLI wrapper (text/json)
+Session Breakdown (last 24h):
+  314d15c0…74e4 — 7,187,790 tokens ($2.56)
+  bc261223…e7fd — 6,669,858 tokens ($8.99)
+  90cb3b3e…1185 — 2,861,466 tokens ($0.71)
+  ... and 20 more sessions
+  Total: 21,691,262 tokens ($16.37)
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Layer 2 is 100% optional. If it fails, the report renders perfectly without it.
 
 | Command | Description |
 |---------|-------------|
-| `/tide_pool` | Tide-themed report (providers + session breakdown) |
-| `/tidepool` | Alias |
-| `/lobster_usage` | Legacy alias |
+| `/tidepools` | Tide-themed report (providers + session breakdown) |
 | `/quota_all` | Plain report (supports flags below) |
 
 ### Flags on `/quota_all`

--- a/TASK.md
+++ b/TASK.md
@@ -1,7 +1,7 @@
-# Tide Pool v2 — Usage Truth Layer
+# Tide Pools v2 — Usage Truth Layer
 
 ## Goal
-Make Tide Pool's numbers match the actual provider dashboards. Add optional enrichment from local session logs.
+Make Tide Pools’ numbers match the actual provider dashboards. Add optional enrichment from local session logs.
 
 ## Current State (v1.6.0)
 - `usage-core.mjs` — single source: `openclaw status --usage --json` for provider quota windows
@@ -100,7 +100,7 @@ Auth: `codex auth` (one-time OAuth flow)
 
 ## Output Format (text, example)
 ```
-🌊 Tide Pool
+🌊 Tide Pools
 
 Providers:
 • OpenAI Codex [Pro]: 45% left (resets in 2h 15m) — via OAuth API
@@ -116,7 +116,7 @@ Session Breakdown (last 24h):
 
 If enrichment fails:
 ```
-🌊 Tide Pool
+🌊 Tide Pools
 
 Providers:
 • OpenAI Codex [Pro]: 45% left (resets in 2h 15m) — via OAuth API

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,126 @@
+# Tide Pool v2 — Usage Truth Layer
+
+## Goal
+Make Tide Pool's numbers match the actual provider dashboards. Add optional enrichment from local session logs.
+
+## Current State (v1.6.0)
+- `usage-core.mjs` — single source: `openclaw status --usage --json` for provider quota windows
+- Venice Diem probe via `~/.openclaw/extensions/diem/diem.py` (parse HTTP headers)
+- CLI (`cli.mjs`) + OpenClaw plugin (`index.ts`) with slash commands
+- Cache layer (45s TTL, filesystem-based)
+- Output: text or JSON
+
+## Architecture for v2
+
+### Layer 1: Provider Source Adapters (ACCURACY — the dashboard numbers)
+Each adapter independently fetches usage from the provider's own API/endpoint.
+
+**Adapter interface:**
+```js
+{
+  id: string,              // e.g. "openai-codex-oauth"
+  provider: string,        // e.g. "openai-codex"
+  probe(): Promise<{       // returns normalized usage
+    available: boolean,
+    windows: [{ label, used, limit, remaining, usedPercent, resetAt }],
+    meta: {},              // provider-specific extras
+    error: string|null
+  }>,
+  isAvailable(): boolean   // quick check (do creds exist?)
+}
+```
+
+**Adapters to build:**
+1. `openclaw-status` — existing `openclaw status --usage --json` (refactored into adapter shape). This is the baseline/fallback for all providers.
+2. `openai-codex-oauth` — read `~/.codex/auth.json` for OAuth token, hit `chatgpt.com/backend-api/wham/usage` directly. This is the primary source for OpenAI/Codex (same endpoint CodexBar uses).
+3. `venice-diem` — existing Diem probe refactored into adapter shape.
+
+**Adapter resolution:**
+- For each provider, run all available adapters
+- Prefer direct API adapters over openclaw-status (higher accuracy)
+- If direct adapter fails, fall back to openclaw-status data for that provider
+- Never block on a failed adapter — timeout + fallback
+
+### Layer 2: Enrichment (VISIBILITY — where usage went)
+Mine OpenClaw session JSONL logs for per-session token breakdowns and cost.
+
+**Critical rule: this layer is 100% optional and fault-isolated.**
+- Wrapped in try/catch at every level
+- If it fails, crashes, or returns garbage: the Layer 1 report renders perfectly fine
+- Never imported or called by Layer 1 code paths
+- Only appended to output after Layer 1 is complete
+
+**What it provides (when working):**
+- Per-session token usage breakdown (which sessions burned what)
+- Per-provider cumulative tokens from local logs
+- Estimated cost from local pricing data
+- Time-series data (usage over the current window)
+
+**Data source:** `/root/.openclaw/agents/mainelobster/sessions/*.jsonl`
+Each JSONL has message entries with `message.usage: { input, output, cacheRead, cacheWrite, totalTokens, cost: { input, output, cacheRead, cacheWrite, total } }`
+
+### Layer 3: Output
+- Text report shows provider numbers + source label ("via OAuth API" / "via OpenClaw status")
+- If enrichment available, append breakdown section
+- JSON output includes both layers with clear separation
+- Confidence/source attribution on every number
+
+## Files to Create/Modify
+
+### New files:
+- `adapters/openclaw-status.mjs` — refactored from current parseUsageStatus()
+- `adapters/openai-codex-oauth.mjs` — new, reads ~/.codex/auth.json, hits usage API
+- `adapters/venice-diem.mjs` — refactored from current getVeniceUsage()
+- `adapters/index.mjs` — adapter registry + resolution logic
+- `enrichment.mjs` — JSONL mining, completely isolated, every export wrapped in try/catch
+
+### Modified files:
+- `usage-core.mjs` — refactor to use adapter registry, add enrichment call (guarded)
+- `cli.mjs` — add `--no-enrich` flag, update output
+- `index.ts` — no changes needed (it just calls cli.mjs)
+- `package.json` — bump to 2.0.0
+- `README.md` — update docs
+
+## Codex CLI Dependency
+The `openai-codex-oauth` adapter reads `~/.codex/auth.json` for the OAuth access token.
+This file exists when the Codex CLI is installed and authenticated.
+If the file doesn't exist, the adapter's `isAvailable()` returns false and it's skipped.
+The adapter is NOT dependent on the Codex CLI being running — it just reads the stored credentials.
+
+Install: `npm install -g @anthropic-ai/codex` (or however it's currently distributed)
+Auth: `codex auth` (one-time OAuth flow)
+
+## Safety Rules
+1. Every adapter has its own timeout (default 10s)
+2. Every adapter failure is caught and reported, never thrown
+3. Enrichment layer failures never affect the main report
+4. Cache works the same as v1 (45s TTL, can bypass with --no-cache)
+5. No secrets written to disk, stdout, or logs
+6. OAuth tokens read from existing credential files, never stored separately
+
+## Output Format (text, example)
+```
+🌊 Tide Pool
+
+Providers:
+• OpenAI Codex [Pro]: 45% left (resets in 2h 15m) — via OAuth API
+• Anthropic [Claude]: 80% left (resets in 5h 30m) — via OpenClaw status
+• Venice [Diem]: 1,247.3200 Diem | Requests: 980/1000 (98% left) — via Diem API
+
+Session Breakdown (last 24h):
+  mainelobster:telegram:direct  — 42,180 tokens ($1.85)
+  mainelobster:main             — 18,400 tokens ($0.72)
+  cron runs                     — 8,900 tokens ($0.31)
+  Total: 69,480 tokens ($2.88)
+```
+
+If enrichment fails:
+```
+🌊 Tide Pool
+
+Providers:
+• OpenAI Codex [Pro]: 45% left (resets in 2h 15m) — via OAuth API
+• Anthropic [Claude]: 80% left (resets in 5h 30m) — via OpenClaw status
+• Venice [Diem]: 1,247.3200 Diem | Requests: 980/1000 (98% left) — via Diem API
+```
+(No session breakdown section — it just doesn't appear. No error shown to user.)

--- a/adapters/anthropic-cli-usage.mjs
+++ b/adapters/anthropic-cli-usage.mjs
@@ -1,0 +1,456 @@
+/**
+ * Adapter: anthropic-cli-usage
+ *
+ * Reads Claude Code `/usage` output from a tmux session (same source Anthrometer uses).
+ *
+ * Behavior:
+ *  - auto (default): only returns Anthropic data when subscription windows are present.
+ *                  If API-mode-only is detected, adapter yields no provider so openclaw-status fallback can win.
+ *  - subscription: require subscription windows from `/usage`.
+ *  - api: disabled at registry layer (falls back to openclaw-status).
+ */
+
+import { execSync } from "node:child_process";
+
+export const id = "anthropic-cli-usage";
+export const provider = "anthropic";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+function sh(cmd, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  return execSync(cmd, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: "/bin/bash",
+  }).trim();
+}
+
+function q(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}
+
+export function isAvailable() {
+  try {
+    sh("command -v tmux >/dev/null && command -v claude >/dev/null", 5000);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stripAnsi(text = "") {
+  return String(text)
+    .replace(/\x1B\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\r/g, "");
+}
+
+function toNumber(value) {
+  if (value == null) return null;
+  const n = Number(String(value).replace(/[^0-9.\-]/g, ""));
+  return Number.isFinite(n) ? n : null;
+}
+
+function utcDateParts(now = new Date()) {
+  return {
+    y: now.getUTCFullYear(),
+    m: now.getUTCMonth(),
+    d: now.getUTCDate(),
+  };
+}
+
+function formatUtcIso(dt) {
+  if (!(dt instanceof Date) || Number.isNaN(dt.getTime())) return null;
+  return dt.toISOString();
+}
+
+function parseResetTime(resetText, now = new Date()) {
+  if (!resetText) return null;
+
+  const raw = String(resetText).trim();
+  const cleaned = raw.replace(/\(UTC\)/gi, "").replace(/\s+/g, " ").trim();
+
+  const monthDayRe = /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+(\d{1,2})(?:,\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm))?$/i;
+  const md = cleaned.match(monthDayRe);
+  if (md) {
+    const monthNames = {
+      jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+      jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+    };
+    const month = monthNames[md[1].slice(0, 3).toLowerCase()];
+    const day = Number(md[2]);
+
+    let hour = 0;
+    let minute = 0;
+    if (md[3]) {
+      hour = Number(md[3]);
+      minute = Number(md[4] || "0");
+      const ap = String(md[5] || "").toLowerCase();
+      if (ap === "pm" && hour < 12) hour += 12;
+      if (ap === "am" && hour === 12) hour = 0;
+    }
+
+    const nowParts = utcDateParts(now);
+    let dt = new Date(Date.UTC(nowParts.y, month, day, hour, minute, 0, 0));
+    if (dt.getTime() <= now.getTime()) {
+      dt = new Date(Date.UTC(nowParts.y + 1, month, day, hour, minute, 0, 0));
+    }
+    return dt;
+  }
+
+  const timeOnlyRe = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i;
+  const t = cleaned.match(timeOnlyRe);
+  if (t) {
+    let hour = Number(t[1]);
+    const minute = Number(t[2] || "0");
+    const ap = t[3].toLowerCase();
+    if (ap === "pm" && hour < 12) hour += 12;
+    if (ap === "am" && hour === 12) hour = 0;
+
+    const { y, m, d } = utcDateParts(now);
+    let dt = new Date(Date.UTC(y, m, d, hour, minute, 0, 0));
+    if (dt.getTime() <= now.getTime()) {
+      dt = new Date(Date.UTC(y, m, d + 1, hour, minute, 0, 0));
+    }
+    return dt;
+  }
+
+  const fallback = new Date(`${cleaned} UTC`);
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms)) return null;
+  if (ms <= 0) return "now";
+
+  const totalMinutes = Math.floor(ms / 60000);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const mins = totalMinutes % 60;
+
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours || days) parts.push(`${hours}h`);
+  parts.push(`${mins}m`);
+  return parts.join(" ");
+}
+
+function sectionSlice(lines, startIndex, maxLookahead = 12) {
+  return lines.slice(startIndex, Math.min(lines.length, startIndex + maxLookahead));
+}
+
+function findHeadingIndex(lines, regex) {
+  return lines.findIndex((line) => regex.test(line.trim()));
+}
+
+function parseWindowSection(lines, headingRegex, now = new Date()) {
+  const idx = findHeadingIndex(lines, headingRegex);
+  if (idx < 0) return null;
+
+  const chunk = sectionSlice(lines, idx, 14).join("\n");
+  const pct = chunk.match(/(\d+)\s*%\s*used/i)?.[1] ?? null;
+  const resetText = chunk.match(/Resets\s+([^\n]+)/i)?.[1]?.trim() ?? null;
+  const resetAt = parseResetTime(resetText, now);
+  const resetInMs = resetAt ? resetAt.getTime() - now.getTime() : null;
+
+  return {
+    pctUsed: pct ? Number(pct) : null,
+    pctRemaining: pct ? Math.max(0, 100 - Number(pct)) : null,
+    resetText,
+    resetAtIso: formatUtcIso(resetAt),
+    resetIn: formatDuration(resetInMs),
+  };
+}
+
+function parseExtraSection(lines, now = new Date()) {
+  const idx = findHeadingIndex(lines, /^extra usage$/i);
+  if (idx < 0) {
+    return {
+      status: /out of extra usage/i.test(lines.join("\n")) ? "exhausted" : "unknown",
+      pctUsed: null,
+      pctRemaining: null,
+      spentUsd: null,
+      limitUsd: null,
+      availableUsd: null,
+      overUsd: null,
+      resetText: null,
+      resetAtIso: null,
+      resetIn: null,
+    };
+  }
+
+  const chunk = sectionSlice(lines, idx, 16).join("\n");
+  const pct = chunk.match(/(\d+)\s*%\s*used/i)?.[1] ?? null;
+
+  let status = "unknown";
+  if (/not enabled/i.test(chunk)) status = "not enabled";
+  else if (/enabled/i.test(chunk)) status = "enabled";
+
+  const money = chunk.match(/\$\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*\$\s*([0-9]+(?:\.[0-9]+)?)\s*spent/i);
+  const spentUsd = toNumber(money?.[1] ?? null);
+  const limitUsd = toNumber(money?.[2] ?? null);
+  const availableUsd = spentUsd != null && limitUsd != null ? Math.max(0, limitUsd - spentUsd) : null;
+  const overUsd = spentUsd != null && limitUsd != null ? Math.max(0, spentUsd - limitUsd) : null;
+
+  const resetText = chunk.match(/Resets\s+([^\n]+)/i)?.[1]?.trim() ?? null;
+  const resetAt = parseResetTime(resetText, now);
+  const resetInMs = resetAt ? resetAt.getTime() - now.getTime() : null;
+
+  if (status === "unknown" && (pct != null || (spentUsd != null && limitUsd != null))) {
+    status = "enabled";
+  }
+  if (/out of extra usage/i.test(chunk)) status = "exhausted";
+
+  return {
+    status,
+    pctUsed: pct ? Number(pct) : null,
+    pctRemaining: pct ? Math.max(0, 100 - Number(pct)) : null,
+    spentUsd,
+    limitUsd,
+    availableUsd,
+    overUsd,
+    resetText,
+    resetAtIso: formatUtcIso(resetAt),
+    resetIn: formatDuration(resetInMs),
+  };
+}
+
+function parseApiBudget(clean, now = new Date()) {
+  const lines = clean.split("\n").map((l) => l.trimEnd());
+  const monthSection = parseWindowSection(lines, /^current month(?:\s*\(.*\))?$/i, now);
+
+  if (!monthSection && !/api\s+usage/i.test(clean)) return null;
+
+  const moneyMatch = clean.match(/\$\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*\$\s*([0-9]+(?:\.[0-9]+)?)\s*spent/i);
+  const spentUsd = toNumber(moneyMatch?.[1] ?? null);
+  const limitUsd = toNumber(moneyMatch?.[2] ?? null);
+  const remainingUsd = spentUsd != null && limitUsd != null ? Math.max(0, limitUsd - spentUsd) : null;
+
+  if (!monthSection && spentUsd == null && limitUsd == null) return null;
+
+  return {
+    label: "api-month",
+    pctUsed: monthSection?.pctUsed ?? null,
+    pctRemaining: monthSection?.pctRemaining ?? null,
+    resetText: monthSection?.resetText ?? null,
+    resetAtIso: monthSection?.resetAtIso ?? null,
+    resetIn: monthSection?.resetIn ?? null,
+    spentUsd,
+    limitUsd,
+    remainingUsd,
+  };
+}
+
+function parseUsage(raw = "", now = new Date()) {
+  const clean = stripAnsi(raw);
+  const lines = clean.split("\n").map((l) => l.trimEnd());
+
+  const fiveHour = parseWindowSection(lines, /^current session$/i, now)
+    || parseWindowSection(lines, /^current 5[ -]?hour(?: window)?$/i, now)
+    || parseWindowSection(lines, /^current 5h(?: window)?$/i, now);
+
+  const week = parseWindowSection(lines, /^current week(?:\s*\(all models\))?$/i, now);
+  const extra = parseExtraSection(lines, now);
+  const api = parseApiBudget(clean, now);
+
+  const profileLine = lines.find((l) => /Claude\s+(Pro|Max|Team|Enterprise|API)/i.test(l)) || null;
+  const mode = /Claude\s+API/i.test(profileLine || "")
+    ? "api"
+    : (fiveHour || week || /Claude\s+(Pro|Max|Team|Enterprise)/i.test(profileLine || ""))
+      ? "subscription"
+      : api
+        ? "api"
+        : "unknown";
+
+  return {
+    mode,
+    fiveHour,
+    week,
+    extra,
+    api,
+    profileLine,
+    clean,
+  };
+}
+
+function looksLikeUsageOutput(raw) {
+  const t = String(raw || "");
+  return /(Current\s+session|Current\s+5[ -]?hour|Current\s+week|Extra\s+usage|Current\s+month|API\s+budget|\b\d+%\s*used\b)/i.test(t);
+}
+
+function fetchUsageRaw(sessionName, timeoutMs, claudeCommand) {
+  const setup = [
+    `tmux has-session -t ${q(sessionName)} 2>/dev/null || tmux new-session -d -s ${q(sessionName)} -x 120 -y 40 ${q(claudeCommand)}`,
+    "sleep 1",
+    `tmux send-keys -t ${q(sessionName)} C-c`,
+    `tmux send-keys -t ${q(sessionName)} C-l`,
+  ].join("; ");
+
+  const attempts = [
+    [
+      `tmux send-keys -t ${q(sessionName)} '/usage'`,
+      "sleep 0.6",
+      `tmux send-keys -t ${q(sessionName)} Enter`,
+      "sleep 0.8",
+      `tmux send-keys -t ${q(sessionName)} Enter`,
+      "sleep 2.5",
+      `tmux capture-pane -t ${q(sessionName)} -p | tail -260`,
+    ].join("; "),
+    [
+      `tmux send-keys -t ${q(sessionName)} '/usage' Enter`,
+      "sleep 1.0",
+      `tmux send-keys -t ${q(sessionName)} Enter`,
+      "sleep 2.5",
+      `tmux capture-pane -t ${q(sessionName)} -p | tail -260`,
+    ].join("; "),
+  ];
+
+  let last = "";
+  for (const step of attempts) {
+    try {
+      const raw = sh(`${setup}; ${step}`, timeoutMs);
+      last = raw;
+      if (looksLikeUsageOutput(raw)) return raw;
+    } catch (err) {
+      last = err?.message || String(err);
+    }
+  }
+  return last;
+}
+
+function providerFromParsed(parsed) {
+  const windows = [];
+  if (parsed?.fiveHour?.pctUsed != null) {
+    windows.push({
+      label: "5h",
+      usedPercent: parsed.fiveHour.pctUsed,
+      leftPercent: parsed.fiveHour.pctRemaining,
+      resetAt: parsed.fiveHour.resetAtIso,
+      resetText: parsed.fiveHour.resetText,
+      resetIn: parsed.fiveHour.resetIn,
+    });
+  }
+  if (parsed?.week?.pctUsed != null) {
+    windows.push({
+      label: "week",
+      usedPercent: parsed.week.pctUsed,
+      leftPercent: parsed.week.pctRemaining,
+      resetAt: parsed.week.resetAtIso,
+      resetText: parsed.week.resetText,
+      resetIn: parsed.week.resetIn,
+    });
+  }
+
+  const extra = parsed?.extra || null;
+  if (extra && (extra.pctUsed != null || (extra.spentUsd != null && extra.limitUsd != null))) {
+    const pctFromMoney = extra.spentUsd != null && extra.limitUsd != null && extra.limitUsd > 0
+      ? (extra.spentUsd / extra.limitUsd) * 100
+      : null;
+    windows.push({
+      label: "extra",
+      usedPercent: extra.pctUsed != null ? extra.pctUsed : (pctFromMoney != null ? Math.round(pctFromMoney) : null),
+      leftPercent: extra.pctRemaining,
+      resetAt: extra.resetAtIso,
+      resetText: extra.resetText,
+      resetIn: extra.resetIn,
+      spentUsd: extra.spentUsd,
+      limitUsd: extra.limitUsd,
+      availableUsd: extra.availableUsd,
+      overUsd: extra.overUsd,
+      status: extra.status,
+    });
+  }
+
+  if (parsed?.mode === "api" && parsed?.api) {
+    windows.push({
+      label: parsed.api.label || "api-month",
+      usedPercent: parsed.api.pctUsed,
+      leftPercent: parsed.api.pctRemaining,
+      resetAt: parsed.api.resetAtIso,
+      resetText: parsed.api.resetText,
+      resetIn: parsed.api.resetIn,
+      spentUsd: parsed.api.spentUsd,
+      limitUsd: parsed.api.limitUsd,
+      remainingUsd: parsed.api.remainingUsd,
+    });
+  }
+
+  return {
+    provider: "anthropic",
+    displayName: "Anthropic Claude",
+    plan: parsed?.mode || null,
+    windows,
+    error: null,
+    anthropic: {
+      mode: parsed?.mode || "unknown",
+      fiveHour: parsed?.fiveHour || null,
+      week: parsed?.week || null,
+      extra: parsed?.extra || null,
+      api: parsed?.api || null,
+    },
+  };
+}
+
+export async function probe(opts = {}) {
+  const sourceMode = String(opts?.anthropicSource || process.env.TIDE_POOLS_ANTHROPIC_SOURCE || "auto").toLowerCase();
+  if (sourceMode === "api") {
+    return {
+      available: false,
+      providers: [],
+      error: "anthropicSource=api (use fallback openclaw-status)",
+      source: id,
+    };
+  }
+
+  try {
+    const tmuxSession = process.env.TIDE_POOLS_ANTHROPIC_TMUX_SESSION || "claude_usage_cmd";
+    const timeoutMs = Number(process.env.TIDE_POOLS_ANTHROPIC_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
+    const claudeCommand = process.env.TIDE_POOLS_ANTHROPIC_CLAUDE_CMD || "claude";
+
+    const raw = fetchUsageRaw(tmuxSession, timeoutMs, claudeCommand);
+    const parsed = parseUsage(raw, new Date());
+
+    if (sourceMode === "subscription" && parsed.mode !== "subscription") {
+      return {
+        available: false,
+        providers: [],
+        error: `subscription mode requested but detected ${parsed.mode || "unknown"}`,
+        source: id,
+      };
+    }
+
+    // auto mode: only own Anthropic when subscription windows are available.
+    if (sourceMode === "auto" && parsed.mode !== "subscription") {
+      return {
+        available: false,
+        providers: [],
+        error: `auto mode defers non-subscription anthropic to fallback (${parsed.mode || "unknown"})`,
+        source: id,
+      };
+    }
+
+    const p = providerFromParsed(parsed);
+    if (!p.windows?.length) {
+      return {
+        available: false,
+        providers: [],
+        error: "No recognizable anthropic usage windows from /usage",
+        source: id,
+      };
+    }
+
+    return {
+      available: true,
+      providers: [p],
+      error: null,
+      source: id,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      providers: [],
+      error: `Anthropic CLI usage probe failed: ${err?.message || String(err)}`,
+      source: id,
+    };
+  }
+}

--- a/adapters/index.mjs
+++ b/adapters/index.mjs
@@ -23,7 +23,7 @@ const ADAPTERS = [
 /**
  * Run a single adapter with timeout protection.
  */
-async function runAdapter(adapter, timeoutMs = 15_000) {
+async function runAdapter(adapter, timeoutMs = 35_000) {
   try {
     if (!adapter.module.isAvailable()) {
       return {

--- a/adapters/index.mjs
+++ b/adapters/index.mjs
@@ -1,0 +1,149 @@
+/**
+ * Adapter Registry
+ *
+ * Manages all source adapters and resolves the best data per provider.
+ * Rules:
+ *  - Direct provider adapters (e.g. openai-codex-oauth) beat generic ones (openclaw-status)
+ *  - If a direct adapter fails, fall back to openclaw-status data for that provider
+ *  - Every adapter runs with its own timeout + try/catch — one failure never blocks others
+ *  - Venice is special (uses Diem, not standard windows) — handled in formatting
+ */
+
+import * as openclawStatus from "./openclaw-status.mjs";
+import * as openaiCodexOauth from "./openai-codex-oauth.mjs";
+import * as veniceDiem from "./venice-diem.mjs";
+
+/** All registered adapters, ordered by priority (direct > generic) */
+const ADAPTERS = [
+  { module: openaiCodexOauth, priority: 10, direct: true },
+  { module: veniceDiem, priority: 10, direct: true },
+  { module: openclawStatus, priority: 0, direct: false },
+];
+
+/**
+ * Run a single adapter with timeout protection.
+ */
+async function runAdapter(adapter, timeoutMs = 15_000) {
+  try {
+    if (!adapter.module.isAvailable()) {
+      return {
+        id: adapter.module.id,
+        skipped: true,
+        reason: "not available",
+        result: null,
+      };
+    }
+
+    const result = await Promise.race([
+      adapter.module.probe(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("Adapter timed out")), timeoutMs)
+      ),
+    ]);
+
+    return {
+      id: adapter.module.id,
+      skipped: false,
+      reason: null,
+      result,
+    };
+  } catch (err) {
+    return {
+      id: adapter.module.id,
+      skipped: false,
+      reason: `error: ${err?.message || String(err)}`,
+      result: {
+        available: false,
+        providers: [],
+        error: err?.message || String(err),
+        source: adapter.module.id,
+      },
+    };
+  }
+}
+
+/**
+ * Resolve the best provider data by running all adapters and merging results.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.includeVenice - include Venice adapter (default: true)
+ * @param {number}  opts.adapterTimeoutMs - per-adapter timeout (default: 15000)
+ * @returns {{ providers: object[], adapterResults: object[] }}
+ */
+export async function resolveAll(opts = {}) {
+  const includeVenice = opts.includeVenice !== false;
+  const timeoutMs = opts.adapterTimeoutMs || 15_000;
+
+  // Filter adapters
+  const active = ADAPTERS.filter((a) => {
+    if (!includeVenice && a.module.id === "venice-diem") return false;
+    return true;
+  });
+
+  // Run all adapters in parallel
+  const adapterResults = await Promise.all(
+    active.map((a) => runAdapter(a, timeoutMs))
+  );
+
+  // Collect provider data, keyed by provider id
+  // Direct adapters take priority; openclaw-status fills gaps
+  const providerMap = new Map(); // provider -> { data, source, priority }
+  const directProviders = new Set(); // providers covered by direct adapters
+
+  // First pass: direct adapters
+  for (const ar of adapterResults) {
+    const adapterDef = active.find((a) => a.module.id === ar.id);
+    if (!adapterDef?.direct) continue;
+    if (ar.skipped || !ar.result?.available) continue;
+
+    for (const p of ar.result.providers || []) {
+      const key = p.provider;
+      directProviders.add(key);
+      providerMap.set(key, {
+        ...p,
+        source: ar.id,
+        sourceType: "direct",
+      });
+    }
+  }
+
+  // Second pass: openclaw-status fills in anything not covered
+  for (const ar of adapterResults) {
+    const adapterDef = active.find((a) => a.module.id === ar.id);
+    if (adapterDef?.direct) continue; // skip direct adapters
+    if (ar.skipped || !ar.result?.available) continue;
+
+    for (const p of ar.result.providers || []) {
+      const key = p.provider;
+      if (directProviders.has(key)) continue; // direct adapter already covers this
+
+      // Check if it's Venice and we have a direct Venice adapter that just failed
+      if (key.includes("venice") && !includeVenice) continue;
+
+      providerMap.set(key, {
+        ...p,
+        source: ar.id,
+        sourceType: "fallback",
+      });
+    }
+  }
+
+  // Convert to array, sorted: direct sources first, then fallbacks
+  const providers = [...providerMap.values()].sort((a, b) => {
+    if (a.sourceType === "direct" && b.sourceType !== "direct") return -1;
+    if (a.sourceType !== "direct" && b.sourceType === "direct") return 1;
+    return (a.displayName || "").localeCompare(b.displayName || "");
+  });
+
+  return {
+    providers,
+    adapterResults: adapterResults.map((ar) => ({
+      id: ar.id,
+      skipped: ar.skipped,
+      reason: ar.reason,
+      available: ar.result?.available ?? false,
+      providerCount: ar.result?.providers?.length ?? 0,
+      error: ar.result?.error || null,
+    })),
+  };
+}

--- a/adapters/index.mjs
+++ b/adapters/index.mjs
@@ -3,7 +3,7 @@
  *
  * Manages all source adapters and resolves the best data per provider.
  * Rules:
- *  - Direct provider adapters (e.g. openai-codex-oauth) beat generic ones (openclaw-status)
+ *  - Direct provider adapters (e.g. openai-codex-oauth, anthropic-cli-usage) beat generic ones (openclaw-status)
  *  - If a direct adapter fails, fall back to openclaw-status data for that provider
  *  - Every adapter runs with its own timeout + try/catch — one failure never blocks others
  *  - Venice is special (uses Diem, not standard windows) — handled in formatting
@@ -11,11 +11,13 @@
 
 import * as openclawStatus from "./openclaw-status.mjs";
 import * as openaiCodexOauth from "./openai-codex-oauth.mjs";
+import * as anthropicCliUsage from "./anthropic-cli-usage.mjs";
 import * as veniceDiem from "./venice-diem.mjs";
 
 /** All registered adapters, ordered by priority (direct > generic) */
 const ADAPTERS = [
   { module: openaiCodexOauth, priority: 10, direct: true },
+  { module: anthropicCliUsage, priority: 10, direct: true },
   { module: veniceDiem, priority: 10, direct: true },
   { module: openclawStatus, priority: 0, direct: false },
 ];
@@ -23,7 +25,7 @@ const ADAPTERS = [
 /**
  * Run a single adapter with timeout protection.
  */
-async function runAdapter(adapter, timeoutMs = 35_000) {
+async function runAdapter(adapter, timeoutMs = 35_000, context = {}) {
   try {
     if (!adapter.module.isAvailable()) {
       return {
@@ -35,7 +37,7 @@ async function runAdapter(adapter, timeoutMs = 35_000) {
     }
 
     const result = await Promise.race([
-      adapter.module.probe(),
+      adapter.module.probe(context),
       new Promise((_, reject) =>
         setTimeout(() => reject(new Error("Adapter timed out")), timeoutMs)
       ),
@@ -73,16 +75,18 @@ async function runAdapter(adapter, timeoutMs = 35_000) {
 export async function resolveAll(opts = {}) {
   const includeVenice = opts.includeVenice !== false;
   const timeoutMs = opts.adapterTimeoutMs || 15_000;
+  const anthropicSource = String(opts.anthropicSource || "auto").toLowerCase();
 
   // Filter adapters
   const active = ADAPTERS.filter((a) => {
     if (!includeVenice && a.module.id === "venice-diem") return false;
+    if (anthropicSource === "api" && a.module.id === "anthropic-cli-usage") return false;
     return true;
   });
 
   // Run all adapters in parallel
   const adapterResults = await Promise.all(
-    active.map((a) => runAdapter(a, timeoutMs))
+    active.map((a) => runAdapter(a, timeoutMs, { anthropicSource }))
   );
 
   // Collect provider data, keyed by provider id

--- a/adapters/openai-codex-oauth.mjs
+++ b/adapters/openai-codex-oauth.mjs
@@ -1,0 +1,272 @@
+/**
+ * Adapter: openai-codex-oauth
+ * Reads OAuth credentials from ~/.codex/auth.json and hits OpenAI's
+ * usage endpoint directly for dashboard-accurate quota data.
+ *
+ * This is the same approach CodexBar uses — first-party session state.
+ * If ~/.codex/auth.json doesn't exist or the token is expired, isAvailable()
+ * returns false and the adapter is skipped gracefully.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import https from "node:https";
+
+const AUTH_PATH = path.join(os.homedir(), ".codex", "auth.json");
+const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const TIMEOUT_MS = 15_000;
+
+export const id = "openai-codex-oauth";
+export const provider = "openai-codex";
+
+/**
+ * Quick check: do we have a credential file?
+ */
+export function isAvailable() {
+  try {
+    return fs.existsSync(AUTH_PATH);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the OAuth token from ~/.codex/auth.json.
+ * The file structure varies — we look for common patterns:
+ *   { "access_token": "..." }
+ *   { "token": "..." }
+ *   { "accessToken": "..." }
+ */
+function readToken() {
+  try {
+    const raw = fs.readFileSync(AUTH_PATH, "utf8");
+    const data = JSON.parse(raw);
+
+    // Try common key names
+    const token =
+      data.access_token ||
+      data.accessToken ||
+      data.token ||
+      data.auth_token ||
+      null;
+
+    if (!token || typeof token !== "string") return null;
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch JSON from a URL with bearer auth.
+ */
+function fetchJson(url, token) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("Request timed out"));
+    }, TIMEOUT_MS);
+
+    const req = https.get(
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": "tide-pool/2.0",
+          Accept: "application/json",
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => {
+          clearTimeout(timeout);
+          if (res.statusCode !== 200) {
+            reject(
+              new Error(`HTTP ${res.statusCode}: ${body.slice(0, 200)}`)
+            );
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (e) {
+            reject(new Error(`JSON parse failed: ${e.message}`));
+          }
+        });
+        res.on("error", (e) => {
+          clearTimeout(timeout);
+          reject(e);
+        });
+      }
+    );
+
+    req.on("error", (e) => {
+      clearTimeout(timeout);
+      reject(e);
+    });
+  });
+}
+
+/**
+ * Parse the usage response from OpenAI's WHAM endpoint.
+ * Response shape varies but commonly includes:
+ *   { "usage": { "used": N, "limit": N, "reset_at": "ISO", ... } }
+ * or nested under plans/windows. We normalize what we find.
+ */
+function parseUsageResponse(data) {
+  const windows = [];
+
+  // Direct usage object (common for Pro/Plus)
+  if (data?.usage) {
+    const u = data.usage;
+    const used = u.used ?? u.messages_used ?? null;
+    const limit = u.limit ?? u.messages_limit ?? null;
+    const remaining =
+      typeof used === "number" && typeof limit === "number"
+        ? Math.max(0, limit - used)
+        : null;
+    const usedPercent =
+      typeof used === "number" && typeof limit === "number" && limit > 0
+        ? Math.round((used / limit) * 100)
+        : null;
+
+    windows.push({
+      label: u.plan || u.label || "usage",
+      used,
+      limit,
+      remaining,
+      usedPercent,
+      leftPercent:
+        typeof usedPercent === "number"
+          ? Math.max(0, 100 - usedPercent)
+          : null,
+      resetAt: u.reset_at || u.resetAt || null,
+    });
+  }
+
+  // Array of windows/tiers (Teams/Enterprise)
+  if (Array.isArray(data?.windows)) {
+    for (const w of data.windows) {
+      const used = w.used ?? null;
+      const limit = w.limit ?? null;
+      const remaining =
+        typeof used === "number" && typeof limit === "number"
+          ? Math.max(0, limit - used)
+          : null;
+      const usedPercent =
+        typeof used === "number" && typeof limit === "number" && limit > 0
+          ? Math.round((used / limit) * 100)
+          : null;
+
+      windows.push({
+        label: w.label || w.name || "window",
+        used,
+        limit,
+        remaining,
+        usedPercent,
+        leftPercent:
+          typeof usedPercent === "number"
+            ? Math.max(0, 100 - usedPercent)
+            : null,
+        resetAt: w.reset_at || w.resetAt || null,
+      });
+    }
+  }
+
+  // Codex-specific: check for codex_usage or similar
+  if (data?.codex_usage) {
+    const cu = data.codex_usage;
+    const used = cu.used ?? null;
+    const limit = cu.limit ?? null;
+    const remaining =
+      typeof used === "number" && typeof limit === "number"
+        ? Math.max(0, limit - used)
+        : null;
+    const usedPercent =
+      typeof used === "number" && typeof limit === "number" && limit > 0
+        ? Math.round((used / limit) * 100)
+        : null;
+
+    windows.push({
+      label: "codex",
+      used,
+      limit,
+      remaining,
+      usedPercent,
+      leftPercent:
+        typeof usedPercent === "number"
+          ? Math.max(0, 100 - usedPercent)
+          : null,
+      resetAt: cu.reset_at || cu.resetAt || null,
+    });
+  }
+
+  return windows;
+}
+
+export async function probe() {
+  try {
+    if (!isAvailable()) {
+      return {
+        available: false,
+        providers: [],
+        error: "~/.codex/auth.json not found",
+        source: id,
+      };
+    }
+
+    const token = readToken();
+    if (!token) {
+      return {
+        available: false,
+        providers: [],
+        error: "Could not read OAuth token from ~/.codex/auth.json",
+        source: id,
+      };
+    }
+
+    const data = await fetchJson(USAGE_URL, token);
+    const windows = parseUsageResponse(data);
+
+    if (!windows.length) {
+      return {
+        available: true,
+        providers: [
+          {
+            provider: "openai-codex",
+            displayName: "OpenAI Codex",
+            plan: data?.plan || data?.subscription || null,
+            windows: [],
+            error: "Usage endpoint returned no recognizable windows",
+            meta: { rawKeys: Object.keys(data || {}) },
+          },
+        ],
+        error: null,
+        source: id,
+      };
+    }
+
+    return {
+      available: true,
+      providers: [
+        {
+          provider: "openai-codex",
+          displayName: "OpenAI Codex",
+          plan: data?.plan || data?.subscription || null,
+          windows,
+          error: null,
+          meta: { rawKeys: Object.keys(data || {}) },
+        },
+      ],
+      error: null,
+      source: id,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      providers: [],
+      error: `OAuth probe failed: ${err?.message || String(err)}`,
+      source: id,
+    };
+  }
+}

--- a/adapters/openai-codex-oauth.mjs
+++ b/adapters/openai-codex-oauth.mjs
@@ -72,7 +72,7 @@ function fetchJson(url, token) {
       {
         headers: {
           Authorization: `Bearer ${token}`,
-          "User-Agent": "tide-pool/2.0",
+          "User-Agent": "tide-pools/2.0",
           Accept: "application/json",
         },
       },

--- a/adapters/openclaw-status.mjs
+++ b/adapters/openclaw-status.mjs
@@ -1,0 +1,108 @@
+/**
+ * Adapter: openclaw-status
+ * Baseline adapter — reads provider usage windows from `openclaw status --usage --json`.
+ * This is the universal fallback: works for any provider OpenClaw tracks.
+ */
+
+import { execSync } from "node:child_process";
+
+const TIMEOUT_MS = 20_000;
+
+function run(cmd) {
+  try {
+    const stdout = execSync(cmd, {
+      encoding: "utf8",
+      timeout: TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: "/bin/bash",
+    });
+    return { ok: true, stdout };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err?.message || String(err),
+      stdout: err?.stdout ? String(err.stdout) : "",
+    };
+  }
+}
+
+function firstJsonObject(raw) {
+  const i = raw.indexOf("{");
+  if (i < 0) return null;
+  try {
+    return JSON.parse(raw.slice(i));
+  } catch {
+    return null;
+  }
+}
+
+export const id = "openclaw-status";
+export const provider = "*"; // covers all providers
+
+export function isAvailable() {
+  // openclaw CLI is always present on an OpenClaw host
+  return true;
+}
+
+export async function probe() {
+  try {
+    const result = run("openclaw status --usage --json 2>/dev/null");
+    if (!result.ok) {
+      return {
+        available: false,
+        providers: [],
+        error: `openclaw status failed: ${result.error}`,
+        source: id,
+      };
+    }
+
+    const parsed = firstJsonObject(result.stdout || "");
+    if (!parsed) {
+      return {
+        available: false,
+        providers: [],
+        error: "Failed to parse openclaw status JSON",
+        source: id,
+      };
+    }
+
+    const rawProviders = parsed?.usage?.providers || [];
+
+    const providers = rawProviders.map((p) => {
+      const windows = (p.windows || []).map((w) => ({
+        label: w.label || "window",
+        usedPercent: w.usedPercent ?? null,
+        leftPercent:
+          typeof w.usedPercent === "number"
+            ? Math.max(0, 100 - Math.round(w.usedPercent))
+            : null,
+        resetAt: w.resetAt || null,
+        limit: w.limit ?? null,
+        remaining: w.remaining ?? null,
+        used: w.used ?? null,
+      }));
+
+      return {
+        provider: p.provider || "unknown",
+        displayName: p.displayName || p.provider || "Unknown",
+        plan: p.plan || null,
+        windows,
+        error: p.error || null,
+      };
+    });
+
+    return {
+      available: true,
+      providers,
+      error: null,
+      source: id,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      providers: [],
+      error: `Unexpected error: ${err?.message || String(err)}`,
+      source: id,
+    };
+  }
+}

--- a/adapters/openclaw-status.mjs
+++ b/adapters/openclaw-status.mjs
@@ -6,7 +6,7 @@
 
 import { execSync } from "node:child_process";
 
-const TIMEOUT_MS = 20_000;
+const TIMEOUT_MS = 30_000;
 
 function run(cmd) {
   try {

--- a/adapters/venice-diem.mjs
+++ b/adapters/venice-diem.mjs
@@ -1,0 +1,165 @@
+/**
+ * Adapter: venice-diem
+ * Fetches Venice balance/rate-limit data via the existing Diem plugin script.
+ * Falls back gracefully if the script doesn't exist or fails.
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+
+const DIEM_SCRIPT = `${process.env.HOME || "/root"}/.openclaw/extensions/diem/diem.py`;
+const TIMEOUT_MS = 15_000;
+
+export const id = "venice-diem";
+export const provider = "venice";
+
+export function isAvailable() {
+  try {
+    return fs.existsSync(DIEM_SCRIPT);
+  } catch {
+    return false;
+  }
+}
+
+function parseDiemOutput(raw) {
+  const lines = String(raw || "").split(/\r?\n/);
+
+  let status = null;
+  let diem = null;
+  let remReq = null;
+  let limReq = null;
+  let remTok = null;
+  let limTok = null;
+
+  for (const line of lines) {
+    const l = line.toLowerCase();
+
+    if (l.includes("http status:")) {
+      status = line.split(":").slice(1).join(":").trim();
+    }
+    if (l.includes("x-venice-balance-diem:")) {
+      const v = parseFloat(line.split(":").slice(1).join(":").trim());
+      if (!Number.isNaN(v)) diem = Number(v.toFixed(6));
+    }
+    if (l.includes("x-ratelimit-remaining-requests:")) {
+      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
+      if (!Number.isNaN(v)) remReq = v;
+    }
+    if (l.includes("x-ratelimit-limit-requests:")) {
+      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
+      if (!Number.isNaN(v)) limReq = v;
+    }
+    if (l.includes("x-ratelimit-remaining-tokens:")) {
+      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
+      if (!Number.isNaN(v)) remTok = v;
+    }
+    if (l.includes("x-ratelimit-limit-tokens:")) {
+      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
+      if (!Number.isNaN(v)) limTok = v;
+    }
+  }
+
+  if (status === "402" && diem == null) diem = 0;
+
+  return { status, diem, remReq, limReq, remTok, limTok };
+}
+
+function pctLeft(remaining, limit) {
+  if (typeof remaining !== "number" || typeof limit !== "number" || limit <= 0)
+    return null;
+  return Math.max(0, Math.min(100, Math.round((remaining / limit) * 100)));
+}
+
+export async function probe() {
+  try {
+    if (!isAvailable()) {
+      return {
+        available: false,
+        providers: [],
+        error: "Diem script not found",
+        source: id,
+      };
+    }
+
+    let stdout;
+    try {
+      stdout = execSync(`python3 ${DIEM_SCRIPT}`, {
+        encoding: "utf8",
+        timeout: TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: "/bin/bash",
+      });
+    } catch (err) {
+      const reason = (err?.stderr || err?.message || "diem script failed").trim();
+      return {
+        available: false,
+        providers: [],
+        error: reason,
+        source: id,
+      };
+    }
+
+    const d = parseDiemOutput(stdout);
+    const hasData = d.diem != null || d.remReq != null || d.remTok != null;
+
+    if (!hasData) {
+      const st = d.status ? ` (HTTP ${d.status})` : "";
+      return {
+        available: true,
+        providers: [
+          {
+            provider: "venice",
+            displayName: "Venice",
+            plan: "Diem",
+            windows: [],
+            error: `No balance headers returned${st}`,
+            diem: null,
+            requests: null,
+            tokens: null,
+          },
+        ],
+        error: null,
+        source: id,
+      };
+    }
+
+    return {
+      available: true,
+      providers: [
+        {
+          provider: "venice",
+          displayName: "Venice",
+          plan: "Diem",
+          windows: [], // Venice doesn't use standard windows
+          error: null,
+          diem: d.diem,
+          requests:
+            d.remReq != null && d.limReq != null
+              ? {
+                  remaining: d.remReq,
+                  limit: d.limReq,
+                  leftPercent: pctLeft(d.remReq, d.limReq),
+                }
+              : null,
+          tokens:
+            d.remTok != null && d.limTok != null
+              ? {
+                  remaining: d.remTok,
+                  limit: d.limTok,
+                  leftPercent: pctLeft(d.remTok, d.limTok),
+                }
+              : null,
+        },
+      ],
+      error: null,
+      source: id,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      providers: [],
+      error: `Unexpected error: ${err?.message || String(err)}`,
+      source: id,
+    };
+  }
+}

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * Tide Pool CLI v2
+ * Tide Pools CLI v2
  *
  * Usage:
- *   tide-pool [options]
+ *   tide-pools [options]
  *
  * Options:
  *   --format text|json    Output format (default: text)
@@ -57,6 +57,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  process.stderr.write(`Tide Pool error: ${err?.message || String(err)}\n`);
+  process.stderr.write(`Tide Pools error: ${err?.message || String(err)}\n`);
   process.exit(1);
 });

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,4 +1,21 @@
 #!/usr/bin/env node
+
+/**
+ * Tide Pool CLI v2
+ *
+ * Usage:
+ *   tide-pool [options]
+ *
+ * Options:
+ *   --format text|json    Output format (default: text)
+ *   --theme plain|tide    Report theme (default: plain)
+ *   --no-venice           Skip Venice/Diem probe
+ *   --no-enrich           Skip session JSONL enrichment
+ *   --no-cache            Bypass cache
+ *   --cache-ttl-ms N      Override cache TTL in ms (default: 45000)
+ *   --lookback-hours N    Enrichment lookback period (default: 24)
+ */
+
 import { collectUsageSnapshot, formatUsageReport } from "./usage-core.mjs";
 
 function parseArgValue(argv, key, fallback = null) {
@@ -11,19 +28,35 @@ const argv = process.argv.slice(2);
 const format = parseArgValue(argv, "--format", "text");
 const theme = parseArgValue(argv, "--theme", "plain");
 const includeVenice = !argv.includes("--no-venice");
+const includeEnrichment = !argv.includes("--no-enrich");
 const noCache = argv.includes("--no-cache");
 const cacheTtlMsRaw = parseArgValue(argv, "--cache-ttl-ms", null);
 const cacheTtlMs = cacheTtlMsRaw == null ? undefined : Number(cacheTtlMsRaw);
+const lookbackRaw = parseArgValue(argv, "--lookback-hours", null);
+const lookbackHours = lookbackRaw == null ? undefined : Number(lookbackRaw);
 
-const snapshot = collectUsageSnapshot({
-  includeVenice,
-  bypassCache: noCache,
-  cacheTtlMs,
-});
+async function main() {
+  const snapshot = await collectUsageSnapshot({
+    includeVenice,
+    includeEnrichment,
+    bypassCache: noCache,
+    cacheTtlMs,
+    enrichmentLookbackHours: lookbackHours,
+  });
 
-if (format === "json") {
-  process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
-  process.exit(0);
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  const report = await formatUsageReport(snapshot, {
+    theme,
+    includeEnrichment,
+  });
+  process.stdout.write(`${report}\n`);
 }
 
-process.stdout.write(`${formatUsageReport(snapshot, { theme })}\n`);
+main().catch((err) => {
+  process.stderr.write(`Tide Pool error: ${err?.message || String(err)}\n`);
+  process.exit(1);
+});

--- a/cli.mjs
+++ b/cli.mjs
@@ -14,6 +14,8 @@
  *   --no-cache            Bypass cache
  *   --cache-ttl-ms N      Override cache TTL in ms (default: 45000)
  *   --lookback-hours N    Enrichment lookback period (default: 24)
+ *   --anthropic-source auto|api|subscription
+ *                        Anthropic source selection (default: auto)
  */
 
 import { collectUsageSnapshot, formatUsageReport } from "./usage-core.mjs";
@@ -34,6 +36,10 @@ const cacheTtlMsRaw = parseArgValue(argv, "--cache-ttl-ms", null);
 const cacheTtlMs = cacheTtlMsRaw == null ? undefined : Number(cacheTtlMsRaw);
 const lookbackRaw = parseArgValue(argv, "--lookback-hours", null);
 const lookbackHours = lookbackRaw == null ? undefined : Number(lookbackRaw);
+const anthropicSourceRaw = String(parseArgValue(argv, "--anthropic-source", "auto") || "auto").toLowerCase();
+const anthropicSource = ["auto", "api", "subscription"].includes(anthropicSourceRaw)
+  ? anthropicSourceRaw
+  : "auto";
 
 async function main() {
   const snapshot = await collectUsageSnapshot({
@@ -42,6 +48,7 @@ async function main() {
     bypassCache: noCache,
     cacheTtlMs,
     enrichmentLookbackHours: lookbackHours,
+    anthropicSource,
   });
 
   if (format === "json") {

--- a/enrichment.mjs
+++ b/enrichment.mjs
@@ -10,14 +10,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
-const DEFAULT_SESSIONS_DIR = path.join(
-  process.env.HOME || "/root",
-  ".openclaw",
-  "agents",
-  "mainelobster",
-  "sessions"
-);
+const AGENTS_DIR = path.join(os.homedir(), ".openclaw", "agents");
 
 // Only look at files modified in the last N hours for performance
 const DEFAULT_LOOKBACK_HOURS = 24;
@@ -26,58 +21,148 @@ const DEFAULT_LOOKBACK_HOURS = 24;
 // but we get most value from recent messages. 256KB per file keeps things fast.
 const MAX_BYTES_PER_FILE = 256 * 1024;
 
+// ─── Session Index ───────────────────────────────────────────────────────────
+
+/**
+ * Build a reverse lookup: sessionId UUID → { label, model, agent, kind }
+ * by reading sessions.json from all agent directories.
+ */
+function buildSessionIndex() {
+  const index = new Map(); // sessionId → metadata
+
+  try {
+    if (!fs.existsSync(AGENTS_DIR)) return index;
+
+    const agents = fs.readdirSync(AGENTS_DIR);
+    for (const agent of agents) {
+      try {
+        const sjPath = path.join(AGENTS_DIR, agent, "sessions", "sessions.json");
+        if (!fs.existsSync(sjPath)) continue;
+
+        const raw = fs.readFileSync(sjPath, "utf8");
+        const data = JSON.parse(raw);
+
+        for (const [key, meta] of Object.entries(data)) {
+          if (!meta || typeof meta !== "object") continue;
+          const sid = meta.sessionId;
+          if (!sid) continue;
+
+          index.set(sid, {
+            key,
+            agent,
+            label:
+              meta.label ||
+              meta.displayName ||
+              meta.subject ||
+              humanizeSessionKey(key),
+            model: meta.model || null,
+            chatType: meta.chatType || null,
+            channel: meta.channel || null,
+          });
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // Return whatever we got
+  }
+
+  return index;
+}
+
+/**
+ * Turn a raw session key into something readable.
+ * "agent:mainelobster:telegram:direct:6566057320" → "DM (telegram)"
+ * "agent:main:cron:abc123" → "Cron job"
+ */
+function humanizeSessionKey(key) {
+  if (!key) return "unknown";
+
+  if (key.includes(":cron:")) return "Cron job";
+  if (key.includes(":direct:")) {
+    const channel = key.match(/:(\w+):direct:/)?.[1] || "dm";
+    return `DM (${channel})`;
+  }
+  if (key.includes(":group:")) {
+    const channel = key.match(/:(\w+):group:/)?.[1] || "group";
+    return `Group (${channel})`;
+  }
+  if (key.endsWith(":main")) return "Main session";
+
+  return key.split(":").slice(-2).join(":");
+}
+
+// ─── Session Scanning ────────────────────────────────────────────────────────
+
 /**
  * Attempt to collect enrichment data from session JSONLs.
- *
- * @param {object} opts
- * @param {string} opts.sessionsDir - path to sessions directory
- * @param {number} opts.lookbackHours - how far back to scan
- * @returns {{ available: boolean, sessions?: object[], totals?: object, error?: string }}
  */
 export function collectEnrichment(opts = {}) {
   try {
-    const sessionsDir = opts.sessionsDir || DEFAULT_SESSIONS_DIR;
     const lookbackHours = opts.lookbackHours || DEFAULT_LOOKBACK_HOURS;
 
-    if (!fs.existsSync(sessionsDir)) {
-      return { available: false, error: "Sessions directory not found" };
+    // Build session index for label/model resolution
+    const sessionIndex = buildSessionIndex();
+
+    // Find all agent session directories
+    const sessionDirs = [];
+    try {
+      const agents = fs.readdirSync(AGENTS_DIR);
+      for (const agent of agents) {
+        const dir = path.join(AGENTS_DIR, agent, "sessions");
+        if (fs.existsSync(dir)) {
+          sessionDirs.push({ agent, dir });
+        }
+      }
+    } catch {
+      return { available: false, error: "Could not list agent directories" };
+    }
+
+    if (!sessionDirs.length) {
+      return { available: false, error: "No session directories found" };
     }
 
     const cutoff = Date.now() - lookbackHours * 60 * 60 * 1000;
-    let files;
-    try {
-      files = fs
-        .readdirSync(sessionsDir)
-        .filter((f) => f.endsWith(".jsonl") && !f.includes(".reset."))
-        .map((f) => {
-          const fp = path.join(sessionsDir, f);
-          try {
-            const stat = fs.statSync(fp);
-            return { name: f, path: fp, mtimeMs: stat.mtimeMs };
-          } catch {
-            return null;
-          }
-        })
-        .filter((f) => f && f.mtimeMs >= cutoff)
-        .sort((a, b) => b.mtimeMs - a.mtimeMs);
-    } catch {
-      return { available: false, error: "Could not list session files" };
+    const allFiles = [];
+
+    for (const { agent, dir } of sessionDirs) {
+      try {
+        const files = fs
+          .readdirSync(dir)
+          .filter((f) => f.endsWith(".jsonl") && !f.includes(".reset."))
+          .map((f) => {
+            const fp = path.join(dir, f);
+            try {
+              const stat = fs.statSync(fp);
+              return { name: f, path: fp, mtimeMs: stat.mtimeMs, agent };
+            } catch {
+              return null;
+            }
+          })
+          .filter((f) => f && f.mtimeMs >= cutoff);
+
+        allFiles.push(...files);
+      } catch {
+        continue;
+      }
     }
 
-    if (!files.length) {
-      return { available: true, sessions: [], totals: emptyTotals() };
+    if (!allFiles.length) {
+      return { available: true, sessions: [], totals: emptyTotals(), byModel: {} };
     }
 
-    // Cap file count to keep scan time under a few seconds
-    const MAX_FILES = 20;
-    const scanned = files.slice(0, MAX_FILES);
+    // Sort by most recently modified, cap at 20
+    allFiles.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    const scanned = allFiles.slice(0, 20);
 
     const sessions = [];
     const totals = emptyTotals();
+    const byModel = {}; // model → { tokens, cost, sessions }
 
     for (const file of scanned) {
       try {
-        const session = scanSession(file);
+        const session = scanSession(file, sessionIndex);
         if (session && session.totalTokens > 0) {
           sessions.push(session);
           totals.input += session.input;
@@ -87,9 +172,17 @@ export function collectEnrichment(opts = {}) {
           totals.totalTokens += session.totalTokens;
           totals.costTotal += session.costTotal;
           totals.messageCount += session.messageCount;
+
+          // Aggregate by model
+          const model = session.model || "unknown";
+          if (!byModel[model]) {
+            byModel[model] = { tokens: 0, cost: 0, sessions: 0 };
+          }
+          byModel[model].tokens += session.totalTokens;
+          byModel[model].cost += session.costTotal;
+          byModel[model].sessions += 1;
         }
       } catch {
-        // Skip broken files silently
         continue;
       }
     }
@@ -100,7 +193,8 @@ export function collectEnrichment(opts = {}) {
     return {
       available: true,
       sessions,
-      totals,
+      totals: { ...totals, costTotal: Number(totals.costTotal.toFixed(6)) },
+      byModel,
       scannedFiles: scanned.length,
       lookbackHours,
     };
@@ -128,18 +222,21 @@ function emptyTotals() {
  * Scan a single session JSONL file for usage data.
  * Reads only the last MAX_BYTES_PER_FILE bytes for large files to stay fast.
  */
-function scanSession(file) {
+function scanSession(file, sessionIndex) {
+  const sessionId = file.name.replace(".jsonl", "");
+
+  // Resolve metadata from sessions.json index
+  const meta = sessionIndex.get(sessionId) || {};
+
   let raw;
   try {
     const stat = fs.statSync(file.path);
     if (stat.size > MAX_BYTES_PER_FILE) {
-      // Read only the tail — we'll miss some early entries but stay fast
       const fd = fs.openSync(file.path, "r");
       const buf = Buffer.alloc(MAX_BYTES_PER_FILE);
       fs.readSync(fd, buf, 0, MAX_BYTES_PER_FILE, stat.size - MAX_BYTES_PER_FILE);
       fs.closeSync(fd);
       raw = buf.toString("utf8");
-      // Drop the first partial line (we likely cut mid-line)
       const firstNewline = raw.indexOf("\n");
       if (firstNewline > 0) raw = raw.slice(firstNewline + 1);
     } else {
@@ -148,9 +245,10 @@ function scanSession(file) {
   } catch {
     return null;
   }
+
   const lines = raw.split(/\r?\n/).filter(Boolean);
 
-  let sessionKey = null;
+  let model = meta.model || null;
   let input = 0;
   let output = 0;
   let cacheRead = 0;
@@ -163,41 +261,39 @@ function scanSession(file) {
     try {
       const entry = JSON.parse(line);
 
-      // Extract session key from session header
-      if (entry.type === "session" && entry.id) {
-        // session id is the UUID, not the key — but it's what we have
-        sessionKey = entry.id;
+      // Pick up model from model-snapshot custom entries (most recent wins)
+      if (
+        entry.type === "custom" &&
+        entry.customType === "model-snapshot" &&
+        entry.data?.modelId
+      ) {
+        model = entry.data.modelId;
       }
 
       // Extract usage from message entries
       if (entry.type === "message") {
         const usage = entry.usage || entry.message?.usage;
         if (usage) {
-          const inp = usage.input || 0;
-          const out = usage.output || 0;
-          const cr = usage.cacheRead || 0;
-          const cw = usage.cacheWrite || 0;
-          const tt = usage.totalTokens || 0;
-          const ct = usage.cost?.total || 0;
-
-          input += inp;
-          output += out;
-          cacheRead += cr;
-          cacheWrite += cw;
-          totalTokens += tt;
-          costTotal += ct;
+          input += usage.input || 0;
+          output += usage.output || 0;
+          cacheRead += usage.cacheRead || 0;
+          cacheWrite += usage.cacheWrite || 0;
+          totalTokens += usage.totalTokens || 0;
+          costTotal += usage.cost?.total || 0;
           messageCount++;
         }
       }
     } catch {
-      // Skip unparseable lines
       continue;
     }
   }
 
   return {
-    sessionId: file.name.replace(".jsonl", ""),
-    sessionKey: sessionKey || file.name.replace(".jsonl", ""),
+    sessionId,
+    label: meta.label || humanizeSessionKey(meta.key),
+    agent: meta.agent || file.agent || "unknown",
+    model,
+    chatType: meta.chatType || null,
     input,
     output,
     cacheRead,
@@ -208,14 +304,11 @@ function scanSession(file) {
   };
 }
 
+// ─── Formatting ──────────────────────────────────────────────────────────────
+
 /**
  * Format enrichment data into a text block for appending to the report.
  * Returns null if enrichment is unavailable or empty.
- *
- * @param {object} enrichment - result from collectEnrichment()
- * @param {object} opts
- * @param {number} opts.maxSessions - max sessions to show (default: 8)
- * @returns {string|null}
  */
 export function formatEnrichment(enrichment, opts = {}) {
   try {
@@ -224,6 +317,7 @@ export function formatEnrichment(enrichment, opts = {}) {
     const maxSessions = opts.maxSessions || 8;
     const totals = enrichment.totals;
     const sessions = enrichment.sessions.slice(0, maxSessions);
+    const byModel = enrichment.byModel || {};
 
     const lines = [];
     const period = enrichment.lookbackHours
@@ -234,21 +328,35 @@ export function formatEnrichment(enrichment, opts = {}) {
 
     for (const s of sessions) {
       const tokens = Number(s.totalTokens).toLocaleString();
-      const cost = s.costTotal > 0 ? ` ($${s.costTotal.toFixed(2)})` : "";
-      const label = truncateSessionId(s.sessionId);
-      lines.push(`  ${label} — ${tokens} tokens${cost}`);
+      const cost = s.costTotal > 0 ? ` · $${s.costTotal.toFixed(2)}` : "";
+      const modelTag = s.model ? ` [${shortModel(s.model)}]` : "";
+      const label = s.label || s.sessionId.slice(0, 12);
+      lines.push(`  ${label}${modelTag} — ${tokens} tok${cost}`);
     }
 
     if (enrichment.sessions.length > maxSessions) {
       const remaining = enrichment.sessions.length - maxSessions;
-      lines.push(`  ... and ${remaining} more sessions`);
+      lines.push(`  ... +${remaining} more`);
     }
 
-    // Totals line
+    // Model breakdown
+    const modelEntries = Object.entries(byModel)
+      .sort((a, b) => b[1].tokens - a[1].tokens);
+
+    if (modelEntries.length > 1) {
+      lines.push(`\nBy Model:`);
+      for (const [m, data] of modelEntries) {
+        const tokens = Number(data.tokens).toLocaleString();
+        const cost = data.cost > 0 ? ` · $${data.cost.toFixed(2)}` : "";
+        lines.push(`  ${shortModel(m)}: ${tokens} tok (${data.sessions} session${data.sessions > 1 ? "s" : ""})${cost}`);
+      }
+    }
+
+    // Totals
     const totalTok = Number(totals.totalTokens).toLocaleString();
     const totalCost =
-      totals.costTotal > 0 ? ` ($${totals.costTotal.toFixed(2)})` : "";
-    lines.push(`  Total: ${totalTok} tokens${totalCost}`);
+      totals.costTotal > 0 ? ` · $${totals.costTotal.toFixed(2)}` : "";
+    lines.push(`\nTotal: ${totalTok} tokens${totalCost}`);
 
     return lines.join("\n");
   } catch {
@@ -257,9 +365,14 @@ export function formatEnrichment(enrichment, opts = {}) {
 }
 
 /**
- * Shorten a UUID session id to something readable.
+ * Shorten model names for display.
  */
-function truncateSessionId(id) {
-  if (!id || id.length <= 16) return id || "unknown";
-  return id.slice(0, 8) + "…" + id.slice(-4);
+function shortModel(model) {
+  if (!model) return "?";
+  // Remove provider prefixes and common suffixes
+  return model
+    .replace(/^(openai-codex|anthropic|google-antigravity|venice|nvidia|ollama)\//, "")
+    .replace(/^moonshotai\//, "")
+    .replace(/-instruct$/, "")
+    .replace(/-preview$/, "");
 }

--- a/enrichment.mjs
+++ b/enrichment.mjs
@@ -1,0 +1,242 @@
+/**
+ * Enrichment Layer — JSONL session mining for usage breakdown.
+ *
+ * 100% OPTIONAL. Every export is wrapped in try/catch.
+ * If anything here fails, the caller gets { available: false } and
+ * the main report renders perfectly without this section.
+ *
+ * This answers "where did my usage go?" — not "how much is left?"
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_SESSIONS_DIR = path.join(
+  process.env.HOME || "/root",
+  ".openclaw",
+  "agents",
+  "mainelobster",
+  "sessions"
+);
+
+// Only look at files modified in the last N hours for performance
+const DEFAULT_LOOKBACK_HOURS = 24;
+
+/**
+ * Attempt to collect enrichment data from session JSONLs.
+ *
+ * @param {object} opts
+ * @param {string} opts.sessionsDir - path to sessions directory
+ * @param {number} opts.lookbackHours - how far back to scan
+ * @returns {{ available: boolean, sessions?: object[], totals?: object, error?: string }}
+ */
+export function collectEnrichment(opts = {}) {
+  try {
+    const sessionsDir = opts.sessionsDir || DEFAULT_SESSIONS_DIR;
+    const lookbackHours = opts.lookbackHours || DEFAULT_LOOKBACK_HOURS;
+
+    if (!fs.existsSync(sessionsDir)) {
+      return { available: false, error: "Sessions directory not found" };
+    }
+
+    const cutoff = Date.now() - lookbackHours * 60 * 60 * 1000;
+    let files;
+    try {
+      files = fs
+        .readdirSync(sessionsDir)
+        .filter((f) => f.endsWith(".jsonl") && !f.includes(".reset."))
+        .map((f) => {
+          const fp = path.join(sessionsDir, f);
+          try {
+            const stat = fs.statSync(fp);
+            return { name: f, path: fp, mtimeMs: stat.mtimeMs };
+          } catch {
+            return null;
+          }
+        })
+        .filter((f) => f && f.mtimeMs >= cutoff)
+        .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    } catch {
+      return { available: false, error: "Could not list session files" };
+    }
+
+    if (!files.length) {
+      return { available: true, sessions: [], totals: emptyTotals() };
+    }
+
+    // Cap file count to avoid scanning hundreds
+    const MAX_FILES = 50;
+    const scanned = files.slice(0, MAX_FILES);
+
+    const sessions = [];
+    const totals = emptyTotals();
+
+    for (const file of scanned) {
+      try {
+        const session = scanSession(file);
+        if (session && session.totalTokens > 0) {
+          sessions.push(session);
+          totals.input += session.input;
+          totals.output += session.output;
+          totals.cacheRead += session.cacheRead;
+          totals.cacheWrite += session.cacheWrite;
+          totals.totalTokens += session.totalTokens;
+          totals.costTotal += session.costTotal;
+          totals.messageCount += session.messageCount;
+        }
+      } catch {
+        // Skip broken files silently
+        continue;
+      }
+    }
+
+    // Sort by totalTokens descending
+    sessions.sort((a, b) => b.totalTokens - a.totalTokens);
+
+    return {
+      available: true,
+      sessions,
+      totals,
+      scannedFiles: scanned.length,
+      lookbackHours,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      error: `Enrichment failed: ${err?.message || String(err)}`,
+    };
+  }
+}
+
+function emptyTotals() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    costTotal: 0,
+    messageCount: 0,
+  };
+}
+
+/**
+ * Scan a single session JSONL file for usage data.
+ */
+function scanSession(file) {
+  const raw = fs.readFileSync(file.path, "utf8");
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+
+  let sessionKey = null;
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  let totalTokens = 0;
+  let costTotal = 0;
+  let messageCount = 0;
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+
+      // Extract session key from session header
+      if (entry.type === "session" && entry.id) {
+        // session id is the UUID, not the key — but it's what we have
+        sessionKey = entry.id;
+      }
+
+      // Extract usage from message entries
+      if (entry.type === "message") {
+        const usage = entry.usage || entry.message?.usage;
+        if (usage) {
+          const inp = usage.input || 0;
+          const out = usage.output || 0;
+          const cr = usage.cacheRead || 0;
+          const cw = usage.cacheWrite || 0;
+          const tt = usage.totalTokens || 0;
+          const ct = usage.cost?.total || 0;
+
+          input += inp;
+          output += out;
+          cacheRead += cr;
+          cacheWrite += cw;
+          totalTokens += tt;
+          costTotal += ct;
+          messageCount++;
+        }
+      }
+    } catch {
+      // Skip unparseable lines
+      continue;
+    }
+  }
+
+  return {
+    sessionId: file.name.replace(".jsonl", ""),
+    sessionKey: sessionKey || file.name.replace(".jsonl", ""),
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens,
+    costTotal: Number(costTotal.toFixed(6)),
+    messageCount,
+  };
+}
+
+/**
+ * Format enrichment data into a text block for appending to the report.
+ * Returns null if enrichment is unavailable or empty.
+ *
+ * @param {object} enrichment - result from collectEnrichment()
+ * @param {object} opts
+ * @param {number} opts.maxSessions - max sessions to show (default: 8)
+ * @returns {string|null}
+ */
+export function formatEnrichment(enrichment, opts = {}) {
+  try {
+    if (!enrichment?.available || !enrichment?.sessions?.length) return null;
+
+    const maxSessions = opts.maxSessions || 8;
+    const totals = enrichment.totals;
+    const sessions = enrichment.sessions.slice(0, maxSessions);
+
+    const lines = [];
+    const period = enrichment.lookbackHours
+      ? `last ${enrichment.lookbackHours}h`
+      : "recent";
+
+    lines.push(`\nSession Breakdown (${period}):`);
+
+    for (const s of sessions) {
+      const tokens = Number(s.totalTokens).toLocaleString();
+      const cost = s.costTotal > 0 ? ` ($${s.costTotal.toFixed(2)})` : "";
+      const label = truncateSessionId(s.sessionId);
+      lines.push(`  ${label} — ${tokens} tokens${cost}`);
+    }
+
+    if (enrichment.sessions.length > maxSessions) {
+      const remaining = enrichment.sessions.length - maxSessions;
+      lines.push(`  ... and ${remaining} more sessions`);
+    }
+
+    // Totals line
+    const totalTok = Number(totals.totalTokens).toLocaleString();
+    const totalCost =
+      totals.costTotal > 0 ? ` ($${totals.costTotal.toFixed(2)})` : "";
+    lines.push(`  Total: ${totalTok} tokens${totalCost}`);
+
+    return lines.join("\n");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shorten a UUID session id to something readable.
+ */
+function truncateSessionId(id) {
+  if (!id || id.length <= 16) return id || "unknown";
+  return id.slice(0, 8) + "…" + id.slice(-4);
+}

--- a/enrichment.mjs
+++ b/enrichment.mjs
@@ -22,6 +22,10 @@ const DEFAULT_SESSIONS_DIR = path.join(
 // Only look at files modified in the last N hours for performance
 const DEFAULT_LOOKBACK_HOURS = 24;
 
+// Max bytes to read per file (tail read). Usage entries are spread throughout
+// but we get most value from recent messages. 256KB per file keeps things fast.
+const MAX_BYTES_PER_FILE = 256 * 1024;
+
 /**
  * Attempt to collect enrichment data from session JSONLs.
  *
@@ -64,8 +68,8 @@ export function collectEnrichment(opts = {}) {
       return { available: true, sessions: [], totals: emptyTotals() };
     }
 
-    // Cap file count to avoid scanning hundreds
-    const MAX_FILES = 50;
+    // Cap file count to keep scan time under a few seconds
+    const MAX_FILES = 20;
     const scanned = files.slice(0, MAX_FILES);
 
     const sessions = [];
@@ -122,9 +126,28 @@ function emptyTotals() {
 
 /**
  * Scan a single session JSONL file for usage data.
+ * Reads only the last MAX_BYTES_PER_FILE bytes for large files to stay fast.
  */
 function scanSession(file) {
-  const raw = fs.readFileSync(file.path, "utf8");
+  let raw;
+  try {
+    const stat = fs.statSync(file.path);
+    if (stat.size > MAX_BYTES_PER_FILE) {
+      // Read only the tail — we'll miss some early entries but stay fast
+      const fd = fs.openSync(file.path, "r");
+      const buf = Buffer.alloc(MAX_BYTES_PER_FILE);
+      fs.readSync(fd, buf, 0, MAX_BYTES_PER_FILE, stat.size - MAX_BYTES_PER_FILE);
+      fs.closeSync(fd);
+      raw = buf.toString("utf8");
+      // Drop the first partial line (we likely cut mid-line)
+      const firstNewline = raw.indexOf("\n");
+      if (firstNewline > 0) raw = raw.slice(firstNewline + 1);
+    } else {
+      raw = fs.readFileSync(file.path, "utf8");
+    }
+  } catch {
+    return null;
+  }
   const lines = raw.split(/\r?\n/).filter(Boolean);
 
   let sessionKey = null;

--- a/enrichment.mjs
+++ b/enrichment.mjs
@@ -309,14 +309,17 @@ function scanSession(file, sessionIndex) {
 /**
  * Format enrichment data into a text block for appending to the report.
  * Returns null if enrichment is unavailable or empty.
+ *
+ * Default view: By Category + By Model (generic, works for anyone).
+ * Detail view (opts.detail=true): adds individual session list.
  */
 export function formatEnrichment(enrichment, opts = {}) {
   try {
     if (!enrichment?.available || !enrichment?.sessions?.length) return null;
 
+    const detail = opts.detail === true;
     const maxSessions = opts.maxSessions || 8;
     const totals = enrichment.totals;
-    const sessions = enrichment.sessions.slice(0, maxSessions);
     const byModel = enrichment.byModel || {};
 
     const lines = [];
@@ -324,36 +327,63 @@ export function formatEnrichment(enrichment, opts = {}) {
       ? `last ${enrichment.lookbackHours}h`
       : "recent";
 
-    lines.push(`\nSession Breakdown (${period}):`);
-
-    for (const s of sessions) {
-      const tokens = Number(s.totalTokens).toLocaleString();
-      const cost = s.costTotal > 0 ? ` · $${s.costTotal.toFixed(2)}` : "";
-      const modelTag = s.model ? ` [${shortModel(s.model)}]` : "";
-      const label = s.label || s.sessionId.slice(0, 12);
-      lines.push(`  ${label}${modelTag} — ${tokens} tok${cost}`);
+    // ── By Category ──
+    const byCategory = {};
+    for (const s of enrichment.sessions) {
+      const cat = categorizeSession(s);
+      if (!byCategory[cat]) {
+        byCategory[cat] = { tokens: 0, cost: 0, sessions: 0 };
+      }
+      byCategory[cat].tokens += s.totalTokens;
+      byCategory[cat].cost += s.costTotal;
+      byCategory[cat].sessions += 1;
     }
 
-    if (enrichment.sessions.length > maxSessions) {
-      const remaining = enrichment.sessions.length - maxSessions;
-      lines.push(`  ... +${remaining} more`);
+    const catEntries = Object.entries(byCategory).sort(
+      (a, b) => b[1].tokens - a[1].tokens
+    );
+
+    lines.push(`\nUsage Breakdown (${period}):`);
+    const catColWidth = Math.max(...catEntries.map(([c]) => c.length), 6);
+    for (const [cat, data] of catEntries) {
+      const tokens = fmtTokens(data.tokens);
+      const cost = data.cost > 0 ? ` · $${data.cost.toFixed(2)}` : "";
+      const count = `(${data.sessions})`;
+      lines.push(`  ${cat.padEnd(catColWidth)}  ${tokens} tok${cost}  ${count}`);
     }
 
-    // Model breakdown
-    const modelEntries = Object.entries(byModel)
-      .sort((a, b) => b[1].tokens - a[1].tokens);
+    // ── By Model ──
+    const modelEntries = Object.entries(byModel).sort(
+      (a, b) => b[1].tokens - a[1].tokens
+    );
 
-    if (modelEntries.length > 1) {
+    if (modelEntries.length > 0) {
       lines.push(`\nBy Model:`);
       for (const [m, data] of modelEntries) {
-        const tokens = Number(data.tokens).toLocaleString();
+        const tokens = fmtTokens(data.tokens);
         const cost = data.cost > 0 ? ` · $${data.cost.toFixed(2)}` : "";
-        lines.push(`  ${shortModel(m)}: ${tokens} tok (${data.sessions} session${data.sessions > 1 ? "s" : ""})${cost}`);
+        lines.push(`  ${shortModel(m)}: ${tokens} tok${cost}`);
       }
     }
 
-    // Totals
-    const totalTok = Number(totals.totalTokens).toLocaleString();
+    // ── Detail: individual sessions (opt-in) ──
+    if (detail) {
+      const sessions = enrichment.sessions.slice(0, maxSessions);
+      lines.push(`\nSessions:`);
+      for (const s of sessions) {
+        const tokens = fmtTokens(s.totalTokens);
+        const cost = s.costTotal > 0 ? ` · $${s.costTotal.toFixed(2)}` : "";
+        const modelTag = s.model ? ` [${shortModel(s.model)}]` : "";
+        const label = s.label || s.sessionId.slice(0, 12);
+        lines.push(`  ${label}${modelTag} — ${tokens} tok${cost}`);
+      }
+      if (enrichment.sessions.length > maxSessions) {
+        lines.push(`  ... +${enrichment.sessions.length - maxSessions} more`);
+      }
+    }
+
+    // ── Totals ──
+    const totalTok = fmtTokens(totals.totalTokens);
     const totalCost =
       totals.costTotal > 0 ? ` · $${totals.costTotal.toFixed(2)}` : "";
     lines.push(`\nTotal: ${totalTok} tokens${totalCost}`);
@@ -362,6 +392,53 @@ export function formatEnrichment(enrichment, opts = {}) {
   } catch {
     return null;
   }
+}
+
+/**
+ * Categorize a session into a generic bucket.
+ */
+function categorizeSession(session) {
+  const key = session.label || "";
+  const chatType = session.chatType || "";
+
+  // Cron jobs
+  if (
+    key.toLowerCase().startsWith("cron") ||
+    (session.sessionId && session.label && session.label.includes("cron"))
+  ) {
+    return "Cron";
+  }
+
+  // Check the raw session key pattern stored in label
+  const rawKey = session._rawKey || key;
+  if (rawKey.includes(":cron:")) return "Cron";
+
+  // Groups
+  if (chatType === "group" || key.includes(":g-") || key.includes("Group")) {
+    return "Groups";
+  }
+
+  // DMs
+  if (chatType === "direct" || key.includes("DM") || key.includes(":direct:")) {
+    return "DMs";
+  }
+
+  // Main session
+  if (key === "Main session" || key.endsWith(":main")) {
+    return "Main";
+  }
+
+  return "Other";
+}
+
+/**
+ * Format token count with K/M suffixes for readability.
+ */
+function fmtTokens(n) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${(n / 1_000).toFixed(0)}K`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export default function register(api: any) {
     try {
       return runCli({ theme: "tide", format: "text" });
     } catch (err: any) {
-      return { text: `🌊 Tide Pool sonar failed.\n${err?.message || String(err)}` };
+      return { text: `🌊 Tide Pools sonar failed.\n${err?.message || String(err)}` };
     }
   };
 
@@ -111,6 +111,6 @@ export default function register(api: any) {
   });
 
   api.logger?.info?.(
-    "[tide-pool] Plugin loaded v2 — /tide_pool, /tidepool, /lobster_usage, /quota_all (adapters + enrichment)"
+    "[tide-pools] Plugin loaded v2 — /tide_pool, /tidepool, /lobster_usage, /quota_all (adapters + enrichment)"
   );
 }

--- a/index.ts
+++ b/index.ts
@@ -12,34 +12,43 @@ function runCli(options: {
   theme?: "tide" | "plain";
   format?: "text" | "json";
   noVenice?: boolean;
+  noEnrich?: boolean;
   noCache?: boolean;
   cacheTtlMs?: number;
+  lookbackHours?: number;
 }) {
   const cli = resolveCliPath();
   const flags: string[] = [];
   flags.push(`--format ${options.format || "text"}`);
   flags.push(`--theme ${options.theme || "plain"}`);
   if (options.noVenice) flags.push("--no-venice");
+  if (options.noEnrich) flags.push("--no-enrich");
   if (options.noCache) flags.push("--no-cache");
   if (typeof options.cacheTtlMs === "number" && !Number.isNaN(options.cacheTtlMs)) {
     flags.push(`--cache-ttl-ms ${Math.max(0, Math.round(options.cacheTtlMs))}`);
   }
+  if (typeof options.lookbackHours === "number" && !Number.isNaN(options.lookbackHours)) {
+    flags.push(`--lookback-hours ${Math.max(1, Math.round(options.lookbackHours))}`);
+  }
 
   const cmd = `node ${JSON.stringify(cli)} ${flags.join(" ")}`;
-  const text = execSync(cmd, { encoding: "utf8", timeout: 20000, stdio: ["ignore", "pipe", "pipe"] });
+  const text = execSync(cmd, { encoding: "utf8", timeout: 30000, stdio: ["ignore", "pipe", "pipe"] });
   return { text: text.trim() };
 }
 
 function parseQuotaArgs(raw: string | undefined) {
   const args = String(raw || "").trim();
   const has = (re: RegExp) => re.test(args);
-  const match = args.match(/--cache-ttl-ms\s+(\d+)/i);
+  const matchCacheTtl = args.match(/--cache-ttl-ms\s+(\d+)/i);
+  const matchLookback = args.match(/--lookback-hours\s+(\d+)/i);
 
   return {
     format: has(/(?:^|\s)(--json|json)(?:\s|$)/i) ? "json" : "text",
     noVenice: has(/(?:^|\s)--no-venice(?:\s|$)/i),
+    noEnrich: has(/(?:^|\s)--no-enrich(?:\s|$)/i),
     noCache: has(/(?:^|\s)--no-cache(?:\s|$)/i),
-    cacheTtlMs: match ? Number(match[1]) : undefined,
+    cacheTtlMs: matchCacheTtl ? Number(matchCacheTtl[1]) : undefined,
+    lookbackHours: matchLookback ? Number(matchLookback[1]) : undefined,
   } as const;
 }
 
@@ -54,7 +63,7 @@ export default function register(api: any) {
 
   api.registerCommand({
     name: "tide_pool",
-    description: "Tide-themed all-provider quota report (no LLM inference)",
+    description: "Tide-themed all-provider quota report with session breakdown (no LLM inference)",
     acceptsArgs: false,
     requireAuth: true,
     handler: tideHandler,
@@ -79,7 +88,8 @@ export default function register(api: any) {
 
   api.registerCommand({
     name: "quota_all",
-    description: "All provider quota windows (supports: --json, --no-venice, --no-cache)",
+    description:
+      "All provider quota windows (supports: --json, --no-venice, --no-enrich, --no-cache, --lookback-hours N)",
     acceptsArgs: true,
     requireAuth: true,
     handler: async (ctx: any) => {
@@ -89,8 +99,10 @@ export default function register(api: any) {
           theme: "plain",
           format: parsed.format,
           noVenice: parsed.noVenice,
+          noEnrich: parsed.noEnrich,
           noCache: parsed.noCache,
           cacheTtlMs: parsed.cacheTtlMs,
+          lookbackHours: parsed.lookbackHours,
         });
       } catch (err: any) {
         return { text: `Quota probe failed.\n${err?.message || String(err)}` };
@@ -99,6 +111,6 @@ export default function register(api: any) {
   });
 
   api.logger?.info?.(
-    "[tide-pool] Plugin loaded - /tide_pool (/tidepool, /lobster_usage alias) and /quota_all registered (standalone; cache+json)",
+    "[tide-pool] Plugin loaded v2 — /tide_pool, /tidepool, /lobster_usage, /quota_all (adapters + enrichment)"
   );
 }

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ function runCli(options: {
   noCache?: boolean;
   cacheTtlMs?: number;
   lookbackHours?: number;
+  anthropicSource?: "auto" | "api" | "subscription";
 }) {
   const cli = resolveCliPath();
   const flags: string[] = [];
@@ -30,6 +31,9 @@ function runCli(options: {
   if (typeof options.lookbackHours === "number" && !Number.isNaN(options.lookbackHours)) {
     flags.push(`--lookback-hours ${Math.max(1, Math.round(options.lookbackHours))}`);
   }
+  if (options.anthropicSource) {
+    flags.push(`--anthropic-source ${options.anthropicSource}`);
+  }
 
   const cmd = `node ${JSON.stringify(cli)} ${flags.join(" ")}`;
   const text = execSync(cmd, { encoding: "utf8", timeout: 60000, stdio: ["ignore", "pipe", "pipe"] });
@@ -41,6 +45,7 @@ function parseQuotaArgs(raw: string | undefined) {
   const has = (re: RegExp) => re.test(args);
   const matchCacheTtl = args.match(/--cache-ttl-ms\s+(\d+)/i);
   const matchLookback = args.match(/--lookback-hours\s+(\d+)/i);
+  const matchAnthropicSource = args.match(/--anthropic-source\s+(auto|api|subscription)/i);
 
   return {
     format: has(/(?:^|\s)(--json|json)(?:\s|$)/i) ? "json" : "text",
@@ -49,6 +54,7 @@ function parseQuotaArgs(raw: string | undefined) {
     noCache: has(/(?:^|\s)--no-cache(?:\s|$)/i),
     cacheTtlMs: matchCacheTtl ? Number(matchCacheTtl[1]) : undefined,
     lookbackHours: matchLookback ? Number(matchLookback[1]) : undefined,
+    anthropicSource: matchAnthropicSource ? String(matchAnthropicSource[1]).toLowerCase() as "auto" | "api" | "subscription" : undefined,
   } as const;
 }
 
@@ -72,7 +78,7 @@ export default function register(api: any) {
   api.registerCommand({
     name: "quota_all",
     description:
-      "All provider quota windows (supports: --json, --no-venice, --no-enrich, --no-cache, --lookback-hours N)",
+      "All provider quota windows (supports: --json, --no-venice, --no-enrich, --no-cache, --lookback-hours N, --anthropic-source auto|api|subscription)",
     acceptsArgs: true,
     requireAuth: true,
     handler: async (ctx: any) => {
@@ -86,6 +92,7 @@ export default function register(api: any) {
           noCache: parsed.noCache,
           cacheTtlMs: parsed.cacheTtlMs,
           lookbackHours: parsed.lookbackHours,
+          anthropicSource: parsed.anthropicSource,
         });
       } catch (err: any) {
         return { text: `Quota probe failed.\n${err?.message || String(err)}` };

--- a/index.ts
+++ b/index.ts
@@ -62,25 +62,8 @@ export default function register(api: any) {
   };
 
   api.registerCommand({
-    name: "tide_pool",
-    description: "Tide-themed all-provider quota report with session breakdown (no LLM inference)",
-    acceptsArgs: false,
-    requireAuth: true,
-    handler: tideHandler,
-  });
-
-  api.registerCommand({
-    name: "tidepool",
-    description: "Alias for /tide_pool",
-    acceptsArgs: false,
-    requireAuth: true,
-    handler: tideHandler,
-  });
-
-  // Backward compatibility alias
-  api.registerCommand({
-    name: "lobster_usage",
-    description: "Alias for /tide_pool",
+    name: "tidepools",
+    description: "Tide Pools all-provider quota report with session breakdown (no LLM inference)",
     acceptsArgs: false,
     requireAuth: true,
     handler: tideHandler,
@@ -111,6 +94,6 @@ export default function register(api: any) {
   });
 
   api.logger?.info?.(
-    "[tide-pools] Plugin loaded v2 — /tide_pool, /tidepool, /lobster_usage, /quota_all (adapters + enrichment)"
+    "[tide-pools] Plugin loaded v2 — /tidepools, /quota_all (adapters + enrichment)"
   );
 }

--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ function runCli(options: {
   }
 
   const cmd = `node ${JSON.stringify(cli)} ${flags.join(" ")}`;
-  const text = execSync(cmd, { encoding: "utf8", timeout: 30000, stdio: ["ignore", "pipe", "pipe"] });
+  const text = execSync(cmd, { encoding: "utf8", timeout: 60000, stdio: ["ignore", "pipe", "pipe"] });
   return { text: text.trim() };
 }
 

--- a/index.ts
+++ b/index.ts
@@ -59,9 +59,19 @@ function parseQuotaArgs(raw: string | undefined) {
 }
 
 export default function register(api: any) {
-  const tideHandler = async () => {
+  const tideHandler = async (ctx: any) => {
     try {
-      return runCli({ theme: "tide", format: "text" });
+      const parsed = parseQuotaArgs(ctx?.args);
+      return runCli({
+        theme: "tide",
+        format: parsed.format,
+        noVenice: parsed.noVenice,
+        noEnrich: parsed.noEnrich,
+        noCache: parsed.noCache,
+        cacheTtlMs: parsed.cacheTtlMs,
+        lookbackHours: parsed.lookbackHours,
+        anthropicSource: parsed.anthropicSource,
+      });
     } catch (err: any) {
       return { text: `🌊 Tide Pools sonar failed.\n${err?.message || String(err)}` };
     }
@@ -69,8 +79,8 @@ export default function register(api: any) {
 
   api.registerCommand({
     name: "tidepools",
-    description: "Tide Pools all-provider quota report with session breakdown (no LLM inference)",
-    acceptsArgs: false,
+    description: "Tide Pools all-provider quota report with session breakdown (supports same flags as /quota_all)",
+    acceptsArgs: true,
     requireAuth: true,
     handler: tideHandler,
   });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
-  "id": "tide-pool",
-  "name": "Tide Pool",
+  "id": "tide-pools",
+  "name": "Tide Pools",
   "version": "1.6.0",
   "description": "Direct /tide_pool (plus aliases) and /quota_all commands for provider quota windows without LLM inference.",
   "configSchema": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@openclaw-ext/tide-pool",
+  "name": "@openclaw-ext/tide-pools",
   "version": "2.0.0",
   "private": true,
   "type": "module",
   "description": "OpenClaw quota usage plugin and CLI with optional Venice augmentation",
   "main": "index.ts",
   "bin": {
+    "tide-pools": "cli.mjs",
     "tide-pool": "cli.mjs",
     "lobster-usage": "cli.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "adapters/index.mjs",
     "adapters/openclaw-status.mjs",
     "adapters/openai-codex-oauth.mjs",
+    "adapters/anthropic-cli-usage.mjs",
     "adapters/venice-diem.mjs",
     "index.ts",
     "openclaw.plugin.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw-ext/tide-pool",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "description": "OpenClaw quota usage plugin and CLI with optional Venice augmentation",
@@ -12,6 +12,11 @@
   "files": [
     "cli.mjs",
     "usage-core.mjs",
+    "enrichment.mjs",
+    "adapters/index.mjs",
+    "adapters/openclaw-status.mjs",
+    "adapters/openai-codex-oauth.mjs",
+    "adapters/venice-diem.mjs",
     "index.ts",
     "openclaw.plugin.json",
     "README.md"

--- a/usage-core.mjs
+++ b/usage-core.mjs
@@ -24,23 +24,28 @@ function resolveCachePath(customPath) {
   return path.join(os.tmpdir(), "openclaw-tide-pools-cache.json");
 }
 
-function readCache(cachePath, ttlMs) {
+function readCache(cachePath, ttlMs, cacheKey = null) {
   if (!ttlMs || ttlMs <= 0) return null;
   try {
     const raw = fs.readFileSync(cachePath, "utf8");
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed.cachedAtMs !== "number" || !parsed.snapshot) return null;
     if (Date.now() - parsed.cachedAtMs > ttlMs) return null;
+    if (cacheKey) {
+      const expected = JSON.stringify(cacheKey);
+      const actual = JSON.stringify(parsed.cacheKey || null);
+      if (expected !== actual) return null;
+    }
     return parsed.snapshot;
   } catch {
     return null;
   }
 }
 
-function writeCache(cachePath, snapshot) {
+function writeCache(cachePath, snapshot, cacheKey = null) {
   try {
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.writeFileSync(cachePath, JSON.stringify({ cachedAtMs: Date.now(), snapshot }));
+    fs.writeFileSync(cachePath, JSON.stringify({ cachedAtMs: Date.now(), snapshot, cacheKey }));
   } catch {
     // best-effort cache
   }
@@ -122,15 +127,17 @@ function countdown(resetAt) {
 export async function collectUsageSnapshot(opts = {}) {
   const includeVenice = opts.includeVenice !== false;
   const includeEnrichment = opts.includeEnrichment !== false;
+  const anthropicSource = String(opts.anthropicSource || "auto").toLowerCase();
   const cacheTtlMs = Number.isFinite(opts.cacheTtlMs)
     ? Number(opts.cacheTtlMs)
     : DEFAULT_CACHE_TTL_MS;
   const cachePath = resolveCachePath(opts.cachePath);
   const bypassCache = opts.bypassCache === true;
+  const cacheKey = { includeVenice, includeEnrichment, anthropicSource };
 
   // Check cache
   if (!bypassCache) {
-    const cached = readCache(cachePath, cacheTtlMs);
+    const cached = readCache(cachePath, cacheTtlMs, cacheKey);
     if (cached) {
       return {
         ...cached,
@@ -140,7 +147,10 @@ export async function collectUsageSnapshot(opts = {}) {
   }
 
   // Layer 1: Adapter resolution
-  const resolved = await resolveAll({ includeVenice });
+  const resolved = await resolveAll({
+    includeVenice,
+    anthropicSource,
+  });
 
   // Layer 2: Enrichment (fault-isolated)
   let enrichment = null;
@@ -159,7 +169,7 @@ export async function collectUsageSnapshot(opts = {}) {
   };
 
   // Write cache
-  if (!bypassCache && cacheTtlMs > 0) writeCache(cachePath, snapshot);
+  if (!bypassCache && cacheTtlMs > 0) writeCache(cachePath, snapshot, cacheKey);
 
   return {
     ...snapshot,
@@ -169,6 +179,55 @@ export async function collectUsageSnapshot(opts = {}) {
 
 // ─── Formatting ──────────────────────────────────────────────────────────────
 
+function anthropicResetText(w) {
+  if (w?.resetIn) return `in ${w.resetIn}`;
+  return countdown(w?.resetAt);
+}
+
+function formatAnthropicLine(p, sourceTag) {
+  const name = p.displayName || "Anthropic";
+  const plan = p.plan ? ` [${p.plan}]` : "";
+  const windows = Array.isArray(p.windows) ? p.windows : [];
+
+  const byLabel = Object.fromEntries(windows.map((w) => [String(w.label || "").toLowerCase(), w]));
+  const five = byLabel["5h"];
+  const week = byLabel["week"];
+  const apiMonth = byLabel["api-month"];
+  const extra = byLabel["extra"];
+
+  const chunks = [];
+  if (five) {
+    const leftTxt = five.leftPercent != null ? `${five.leftPercent}% left` : "left unknown";
+    chunks.push(`5h: ${leftTxt} (${anthropicResetText(five)})`);
+  }
+  if (week) {
+    const leftTxt = week.leftPercent != null ? `${week.leftPercent}% left` : "left unknown";
+    chunks.push(`week: ${leftTxt} (${anthropicResetText(week)})`);
+  }
+  if (apiMonth) {
+    const leftTxt = apiMonth.leftPercent != null ? `${apiMonth.leftPercent}% left` : "left unknown";
+    chunks.push(`api-month: ${leftTxt} (${anthropicResetText(apiMonth)})`);
+  }
+
+  const head = chunks.length
+    ? `• ${name}${plan}: ${chunks.join(" | ")}${sourceTag}`
+    : `• ${name}${plan}: no quota windows${sourceTag}`;
+
+  const extraParts = [];
+  if (extra) {
+    if (extra.status) extraParts.push(`status ${extra.status}`);
+    if (extra.spentUsd != null && extra.limitUsd != null) {
+      extraParts.push(`$${Number(extra.spentUsd).toFixed(2)} / $${Number(extra.limitUsd).toFixed(2)} spent`);
+    }
+    if (extra.availableUsd != null) extraParts.push(`$${Number(extra.availableUsd).toFixed(2)} available`);
+    if (extra.overUsd != null && Number(extra.overUsd) > 0) extraParts.push(`over by $${Number(extra.overUsd).toFixed(2)}`);
+    if (extra.resetAt || extra.resetIn) extraParts.push(`reset ${anthropicResetText(extra)}`);
+  }
+
+  if (!extraParts.length) return head;
+  return `${head}\n  ↳ extra: ${extraParts.join(" · ")}`;
+}
+
 function formatProviderLine(p) {
   const name = p.displayName || p.provider || "Unknown provider";
   const plan = p.plan ? ` [${p.plan}]` : "";
@@ -177,6 +236,11 @@ function formatProviderLine(p) {
   // Venice is special: uses Diem balance + rate limits
   if (p.provider === "venice") {
     return formatVeniceLine(p, sourceTag);
+  }
+
+  // Anthropic is special: subscription windows + extra usage details
+  if (String(p.provider || "").toLowerCase() === "anthropic") {
+    return formatAnthropicLine(p, sourceTag);
   }
 
   if (p.error) return `• ${name}${plan}: unavailable — ${p.error}${sourceTag}`;
@@ -224,6 +288,7 @@ function formatVeniceLine(p, sourceTag) {
 function formatSourceName(source) {
   const map = {
     "openai-codex-oauth": "OAuth API",
+    "anthropic-cli-usage": "Claude /usage",
     "openclaw-status": "OpenClaw status",
     "venice-diem": "Diem API",
   };

--- a/usage-core.mjs
+++ b/usage-core.mjs
@@ -1,5 +1,5 @@
 /**
- * Tide Pool v2 — Usage Core
+ * Tide Pools v2 — Usage Core
  *
  * Architecture:
  *   Layer 1 (Accuracy): Adapter registry fetches dashboard-accurate numbers
@@ -21,7 +21,7 @@ function resolveCachePath(customPath) {
   if (customPath) return customPath;
   if (process.env.TIDE_POOL_CACHE_PATH) return process.env.TIDE_POOL_CACHE_PATH;
   if (process.env.LOBSTER_USAGE_CACHE_PATH) return process.env.LOBSTER_USAGE_CACHE_PATH;
-  return path.join(os.tmpdir(), "openclaw-tide-pool-cache.json");
+  return path.join(os.tmpdir(), "openclaw-tide-pools-cache.json");
 }
 
 function readCache(cachePath, ttlMs) {
@@ -240,7 +240,7 @@ function formatSourceName(source) {
  */
 export async function formatUsageReport(snapshot, opts = {}) {
   const theme = opts.theme || "plain";
-  const heading = theme === "plain" ? "Provider Quota Board" : "🌊 Tide Pool";
+  const heading = theme === "plain" ? "Provider Quota Board" : "🌊 Tide Pools";
   const includeEnrichment = opts.includeEnrichment !== false;
 
   const lines = [heading, ""];

--- a/usage-core.mjs
+++ b/usage-core.mjs
@@ -1,173 +1,21 @@
-import { execSync } from "node:child_process";
+/**
+ * Tide Pool v2 — Usage Core
+ *
+ * Architecture:
+ *   Layer 1 (Accuracy): Adapter registry fetches dashboard-accurate numbers
+ *                        from provider APIs with priority + fallback.
+ *   Layer 2 (Enrichment): JSONL session mining shows where usage went.
+ *                          100% optional — never blocks Layer 1.
+ */
+
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resolveAll } from "./adapters/index.mjs";
 
 const DEFAULT_CACHE_TTL_MS = 45_000;
 
-function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return null;
-  }
-}
-
-function firstJsonObject(raw) {
-  const i = raw.indexOf("{");
-  if (i < 0) return null;
-  return safeJsonParse(raw.slice(i));
-}
-
-function run(cmd, timeoutMs = 20000) {
-  try {
-    const stdout = execSync(cmd, {
-      encoding: "utf8",
-      timeout: timeoutMs,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: "/bin/bash",
-    });
-    return { ok: true, stdout };
-  } catch (err) {
-    return {
-      ok: false,
-      error: err?.message || String(err),
-      stdout: err?.stdout ? String(err.stdout) : "",
-      stderr: err?.stderr ? String(err.stderr) : "",
-    };
-  }
-}
-
-function countdown(resetAtMs) {
-  if (!resetAtMs) return "reset unknown";
-  const delta = Math.max(0, resetAtMs - Date.now());
-  const totalMins = Math.floor(delta / 60000);
-  const d = Math.floor(totalMins / 1440);
-  const h = Math.floor((totalMins % 1440) / 60);
-  const m = totalMins % 60;
-  const parts = [];
-  if (d) parts.push(`${d}d`);
-  if (h) parts.push(`${h}h`);
-  if (m || parts.length === 0) parts.push(`${m}m`);
-  return `in ${parts.join(" ")}`;
-}
-
-function leftPercent(usedPercent) {
-  if (typeof usedPercent !== "number" || Number.isNaN(usedPercent)) return null;
-  return Math.max(0, 100 - Math.round(usedPercent));
-}
-
-function pctLeft(remaining, limit) {
-  if (typeof remaining !== "number" || typeof limit !== "number" || limit <= 0) return null;
-  return Math.max(0, Math.min(100, Math.round((remaining / limit) * 100)));
-}
-
-function parseUsageStatus() {
-  const probe = run("openclaw status --usage --json 2>/dev/null");
-  if (!probe.ok) return { providers: [], error: `status call failed: ${probe.error}` };
-
-  const parsed = firstJsonObject(probe.stdout || "");
-  if (!parsed) return { providers: [], error: "status JSON parse failed" };
-
-  return {
-    providers: parsed?.usage?.providers || [],
-    raw: parsed,
-    error: null,
-  };
-}
-
-function parseVeniceFromDiemOutput(raw) {
-  const lines = String(raw || "").split(/\r?\n/);
-
-  let status;
-  let diem;
-  let remReq;
-  let limReq;
-  let remTok;
-  let limTok;
-
-  for (const line of lines) {
-    const l = line.toLowerCase();
-    if (l.includes("http status:")) status = line.split(":").slice(1).join(":").trim();
-
-    if (l.includes("x-venice-balance-diem:")) {
-      const v = parseFloat(line.split(":").slice(1).join(":").trim());
-      if (!Number.isNaN(v)) diem = Number(v.toFixed(6));
-    }
-
-    if (l.includes("x-ratelimit-remaining-requests:")) {
-      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
-      if (!Number.isNaN(v)) remReq = v;
-    }
-    if (l.includes("x-ratelimit-limit-requests:")) {
-      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
-      if (!Number.isNaN(v)) limReq = v;
-    }
-    if (l.includes("x-ratelimit-remaining-tokens:")) {
-      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
-      if (!Number.isNaN(v)) remTok = v;
-    }
-    if (l.includes("x-ratelimit-limit-tokens:")) {
-      const v = parseInt(line.split(":").slice(1).join(":").trim(), 10);
-      if (!Number.isNaN(v)) limTok = v;
-    }
-  }
-
-  if (status === "402" && diem == null) diem = 0;
-
-  return {
-    available: diem != null || remReq != null || remTok != null,
-    status: status || null,
-    diem,
-    requests:
-      remReq != null && limReq != null
-        ? {
-            remaining: remReq,
-            limit: limReq,
-            leftPercent: pctLeft(remReq, limReq),
-          }
-        : null,
-    tokens:
-      remTok != null && limTok != null
-        ? {
-            remaining: remTok,
-            limit: limTok,
-            leftPercent: pctLeft(remTok, limTok),
-          }
-        : null,
-  };
-}
-
-function getVeniceUsage() {
-  const probe = run("python3 ~/.openclaw/extensions/diem/diem.py", 15000);
-  if (!probe.ok) {
-    const reason = (probe.stderr || probe.error || "venice check failed").trim();
-    return {
-      source: "diem-plugin",
-      available: false,
-      optional: true,
-      error: reason,
-      raw: probe,
-      data: null,
-    };
-  }
-
-  const data = parseVeniceFromDiemOutput(probe.stdout);
-  return {
-    source: "diem-plugin",
-    available: data.available,
-    optional: true,
-    error: null,
-    data,
-    raw: probe.stdout,
-  };
-}
-
-function providerLooksLikeVenice(p) {
-  const id = String(p?.provider || "").toLowerCase();
-  const dn = String(p?.displayName || "").toLowerCase();
-  return id.includes("venice") || dn.includes("venice");
-}
+// ─── Cache ──────────────────────────────────��────────────────────────────────
 
 function resolveCachePath(customPath) {
   if (customPath) return customPath;
@@ -180,7 +28,7 @@ function readCache(cachePath, ttlMs) {
   if (!ttlMs || ttlMs <= 0) return null;
   try {
     const raw = fs.readFileSync(cachePath, "utf8");
-    const parsed = safeJsonParse(raw);
+    const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed.cachedAtMs !== "number" || !parsed.snapshot) return null;
     if (Date.now() - parsed.cachedAtMs > ttlMs) return null;
     return parsed.snapshot;
@@ -192,22 +40,95 @@ function readCache(cachePath, ttlMs) {
 function writeCache(cachePath, snapshot) {
   try {
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    const payload = {
-      cachedAtMs: Date.now(),
-      snapshot,
-    };
-    fs.writeFileSync(cachePath, JSON.stringify(payload));
+    fs.writeFileSync(cachePath, JSON.stringify({ cachedAtMs: Date.now(), snapshot }));
   } catch {
-    // best effort cache only
+    // best-effort cache
   }
 }
 
-export function collectUsageSnapshot(opts = {}) {
+// ─── Enrichment (fault-isolated import) ──────────────────────────────────────
+
+let _enrichmentModule = null;
+
+async function loadEnrichment() {
+  if (_enrichmentModule !== null) return _enrichmentModule;
+  try {
+    _enrichmentModule = await import("./enrichment.mjs");
+  } catch {
+    _enrichmentModule = false; // mark as failed so we don't retry
+  }
+  return _enrichmentModule;
+}
+
+async function safeCollectEnrichment(opts) {
+  try {
+    const mod = await loadEnrichment();
+    if (!mod) return { available: false };
+    return mod.collectEnrichment(opts);
+  } catch {
+    return { available: false };
+  }
+}
+
+async function safeFormatEnrichment(enrichment, opts) {
+  try {
+    const mod = await loadEnrichment();
+    if (!mod) return null;
+    return mod.formatEnrichment(enrichment, opts);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function countdown(resetAt) {
+  let resetAtMs;
+  if (typeof resetAt === "number") {
+    resetAtMs = resetAt;
+  } else if (typeof resetAt === "string") {
+    resetAtMs = new Date(resetAt).getTime();
+  } else {
+    return "reset unknown";
+  }
+
+  if (Number.isNaN(resetAtMs)) return "reset unknown";
+
+  const delta = Math.max(0, resetAtMs - Date.now());
+  const totalMins = Math.floor(delta / 60000);
+  const d = Math.floor(totalMins / 1440);
+  const h = Math.floor((totalMins % 1440) / 60);
+  const m = totalMins % 60;
+  const parts = [];
+  if (d) parts.push(`${d}d`);
+  if (h) parts.push(`${h}h`);
+  if (m || parts.length === 0) parts.push(`${m}m`);
+  return `in ${parts.join(" ")}`;
+}
+
+// ─── Snapshot Collection ─────────────────────────────────────────────────────
+
+/**
+ * Collect a full usage snapshot: adapters + optional enrichment.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.includeVenice
+ * @param {boolean} opts.includeEnrichment
+ * @param {number}  opts.cacheTtlMs
+ * @param {string}  opts.cachePath
+ * @param {boolean} opts.bypassCache
+ * @param {number}  opts.enrichmentLookbackHours
+ */
+export async function collectUsageSnapshot(opts = {}) {
   const includeVenice = opts.includeVenice !== false;
-  const cacheTtlMs = Number.isFinite(opts.cacheTtlMs) ? Number(opts.cacheTtlMs) : DEFAULT_CACHE_TTL_MS;
+  const includeEnrichment = opts.includeEnrichment !== false;
+  const cacheTtlMs = Number.isFinite(opts.cacheTtlMs)
+    ? Number(opts.cacheTtlMs)
+    : DEFAULT_CACHE_TTL_MS;
   const cachePath = resolveCachePath(opts.cachePath);
   const bypassCache = opts.bypassCache === true;
 
+  // Check cache
   if (!bypassCache) {
     const cached = readCache(cachePath, cacheTtlMs);
     if (cached) {
@@ -218,19 +139,26 @@ export function collectUsageSnapshot(opts = {}) {
     }
   }
 
-  const status = parseUsageStatus();
-  const providers = Array.isArray(status.providers) ? status.providers : [];
-  const hasVeniceInStatus = providers.some(providerLooksLikeVenice);
-  const venice = includeVenice && !hasVeniceInStatus ? getVeniceUsage() : null;
+  // Layer 1: Adapter resolution
+  const resolved = await resolveAll({ includeVenice });
+
+  // Layer 2: Enrichment (fault-isolated)
+  let enrichment = null;
+  if (includeEnrichment) {
+    enrichment = await safeCollectEnrichment({
+      lookbackHours: opts.enrichmentLookbackHours,
+    });
+  }
 
   const snapshot = {
     generatedAt: new Date().toISOString(),
-    statusError: status.error || null,
-    providers,
-    hasVeniceInStatus,
-    venice,
+    version: "2.0.0",
+    providers: resolved.providers,
+    adapterResults: resolved.adapterResults,
+    enrichment,
   };
 
+  // Write cache
   if (!bypassCache && cacheTtlMs > 0) writeCache(cachePath, snapshot);
 
   return {
@@ -239,64 +167,109 @@ export function collectUsageSnapshot(opts = {}) {
   };
 }
 
+// ─── Formatting ──────────────────────────────────────────────────────────────
+
 function formatProviderLine(p) {
   const name = p.displayName || p.provider || "Unknown provider";
   const plan = p.plan ? ` [${p.plan}]` : "";
+  const sourceTag = p.source ? ` — via ${formatSourceName(p.source)}` : "";
 
-  if (p.error) return `• ${name}${plan}: unavailable — ${p.error}`;
+  // Venice is special: uses Diem balance + rate limits
+  if (p.provider === "venice") {
+    return formatVeniceLine(p, sourceTag);
+  }
+
+  if (p.error) return `• ${name}${plan}: unavailable — ${p.error}${sourceTag}`;
 
   const windows = Array.isArray(p.windows) ? p.windows : [];
-  if (!windows.length) return `• ${name}${plan}: no quota windows returned`;
+  if (!windows.length) return `• ${name}${plan}: no quota windows${sourceTag}`;
 
   const chunks = windows.map((w) => {
     const label = w.label || "window";
-    const left = leftPercent(w.usedPercent);
-    const leftTxt = left == null ? "left unknown" : `${left}% left`;
+    const leftTxt =
+      w.leftPercent != null ? `${w.leftPercent}% left` : "left unknown";
     return `${label}: ${leftTxt} (${countdown(w.resetAt)})`;
   });
 
-  return `• ${name}${plan}: ${chunks.join(" | ")}`;
+  return `• ${name}${plan}: ${chunks.join(" | ")}${sourceTag}`;
 }
 
-function formatVeniceLine(venice) {
-  if (!venice) return null;
-  if (!venice.available) return `• Venice [Diem]: unavailable — ${venice.error || "unknown error"}`;
-
-  const chunks = [];
-  if (venice?.data?.diem != null) chunks.push(`Diem: ${Number(venice.data.diem).toFixed(4)}`);
-
-  const req = venice?.data?.requests;
-  if (req) chunks.push(`Requests: ${req.remaining}/${req.limit} (${req.leftPercent ?? "?"}% left)`);
-
-  const tok = venice?.data?.tokens;
-  if (tok)
-    chunks.push(
-      `Tokens: ${Number(tok.remaining).toLocaleString()}/${Number(tok.limit).toLocaleString()} (${tok.leftPercent ?? "?"}% left)`,
-    );
-
-  if (!chunks.length) {
-    const st = venice?.data?.status ? ` (HTTP ${venice.data.status})` : "";
-    return `• Venice [Diem]: no balance headers returned${st}`;
+function formatVeniceLine(p, sourceTag) {
+  if (p.error && !p.diem && !p.requests && !p.tokens) {
+    return `• Venice [Diem]: unavailable — ${p.error}${sourceTag}`;
   }
 
-  return `• Venice [Diem]: ${chunks.join(" | ")}`;
+  const chunks = [];
+  if (p.diem != null) chunks.push(`Diem: ${Number(p.diem).toFixed(4)}`);
+
+  if (p.requests) {
+    chunks.push(
+      `Requests: ${p.requests.remaining}/${p.requests.limit} (${p.requests.leftPercent ?? "?"}% left)`
+    );
+  }
+
+  if (p.tokens) {
+    chunks.push(
+      `Tokens: ${Number(p.tokens.remaining).toLocaleString()}/${Number(p.tokens.limit).toLocaleString()} (${p.tokens.leftPercent ?? "?"}% left)`
+    );
+  }
+
+  if (!chunks.length) {
+    return `• Venice [Diem]: no balance data${sourceTag}`;
+  }
+
+  return `• Venice [Diem]: ${chunks.join(" | ")}${sourceTag}`;
 }
 
-export function formatUsageReport(snapshot, opts = {}) {
+function formatSourceName(source) {
+  const map = {
+    "openai-codex-oauth": "OAuth API",
+    "openclaw-status": "OpenClaw status",
+    "venice-diem": "Diem API",
+  };
+  return map[source] || source;
+}
+
+/**
+ * Format a full usage report from a snapshot.
+ *
+ * @param {object} snapshot - from collectUsageSnapshot()
+ * @param {object} opts
+ * @param {string} opts.theme - "plain" | "tide"
+ * @param {boolean} opts.includeEnrichment
+ */
+export async function formatUsageReport(snapshot, opts = {}) {
   const theme = opts.theme || "plain";
   const heading = theme === "plain" ? "Provider Quota Board" : "🌊 Tide Pool";
+  const includeEnrichment = opts.includeEnrichment !== false;
 
-  const lines = [heading];
+  const lines = [heading, ""];
   const providers = Array.isArray(snapshot?.providers) ? snapshot.providers : [];
 
   if (!providers.length) {
-    lines.push("• No provider usage windows found. (Credentials/scope may be missing.)");
+    lines.push(
+      "• No provider usage data found. (Credentials/scope may be missing.)"
+    );
   } else {
-    for (const p of providers) lines.push(formatProviderLine(p));
+    for (const p of providers) {
+      lines.push(formatProviderLine(p));
+    }
   }
 
-  const veniceLine = formatVeniceLine(snapshot?.venice || null);
-  if (veniceLine) lines.push(veniceLine);
+  // Enrichment section (fault-isolated)
+  if (includeEnrichment && snapshot?.enrichment) {
+    const enrichText = await safeFormatEnrichment(snapshot.enrichment);
+    if (enrichText) {
+      lines.push(enrichText);
+    }
+  }
 
   return lines.join("\n");
 }
+
+// ─── Backward Compatibility ──────────────────────────────────────────────────
+// These re-exports keep the CLI and plugin working during the transition.
+// They can be removed in a future version once cli.mjs and index.ts are updated.
+
+export { collectUsageSnapshot as collectUsageSnapshotV2 };
+export { formatUsageReport as formatUsageReportV2 };


### PR DESCRIPTION
Publishes the previously local usage-truth branch so Morty/Nick can pull and test.

## Included
- Adapter registry + enrichment layer
- Session/model enrichment in output
- Per-model breakdown support
- Safer timeouts/caps for large session files
- Tide Pools plural rebrand updates

## Notes
- This unblocks testing beyond quota-window-only output on .
- OpenRouter-specific spend enhancement can be added as a follow-up in this branch/PR if desired.